### PR TITLE
2.1.0: RTI-agnostic HLA backends (Pitch pRTI) + unified DEVS tick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0] — 2026-06-28
+
 ### Added
 - RTI-agnostic HLA interface so backends other than the test loopback can be
   plugged in:
@@ -165,7 +167,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `SysExecutor` with V_TIME and R_TIME execution modes, port-based
   coupling, and `dill`-backed serialization.
 
-[Unreleased]: https://github.com/eventsim/pyjevsim/compare/v2.0.1...HEAD
+[Unreleased]: https://github.com/eventsim/pyjevsim/compare/v2.1.0...HEAD
+[2.1.0]: https://github.com/eventsim/pyjevsim/compare/v2.0.1...v2.1.0
 [2.0.1]: https://github.com/eventsim/pyjevsim/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/eventsim/pyjevsim/compare/v1.3.1...v2.0.0
 [1.3.1]: https://github.com/eventsim/pyjevsim/compare/v1.3.0...v1.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- RTI-agnostic HLA interface so backends other than the test loopback can be
+  plugged in:
+  - `RTIConnector` template-method base class (`pyjevsim/hla/transport.py`) —
+    a new backend implements only `_do_send` / `_do_request_time_advance`
+    (plus optional lifecycle hooks); direction enforcement, codec calls,
+    single-callback dispatch, the join/resign state machine and idempotent
+    close are inherited.
+  - `RTICapabilities` (feature negotiation), `Codec` / `IdentityCodec`
+    (FOM encoding decoupled from transport), and a name→factory registry
+    (`register_rti` / `create_rti` / `available_rtis`).
+  - `docs/hla/rti_interface.md` documenting how to add a backend.
+- RTI backends under `pyjevsim/hla/backends/`:
+  - `InProcessRTI` — multi-federate in-process bus (no Java) for tests/demos.
+  - `PitchTransport` — IEEE 1516-2010 backend for **Pitch pRTI** via JPype.
+    Verified live against Pitch pRTI Free 5.5.2 with Temurin 11.
+- `examples/hla_pingpong/` — two-federate (ping/pong) example demonstrating
+  federation join/resign, interaction exchange, and object-attribute
+  synchronization. Runs offline (`run_inprocess.py`) or against a live CRC
+  (`run_pitch.py`); FOM in `fom/PingPong.xml`.
+- Tests: `tests/hla/test_rti_interface.py`, `tests/hla/test_pingpong.py`
+  (always run), `tests/hla/test_pitch_backend.py` (guarded; live when
+  `PYJEVSIM_JVM` + `PYJEVSIM_PITCH_LIVE` + a running CRC are present).
+- `hla-pitch` optional dependency extra (`jpype1`).
+
+### Changed
+- `SysExecutor.schedule` (V_TIME/R_TIME) and `SysExecutor.step` (HLA_TIME) now
+  share a single two-phase tick body, `SysExecutor._run_instant`, so all three
+  execution modes deliver identical DEVS semantics.
+
+### Fixed
+- External events on the V_TIME/R_TIME path were delivered by a legacy
+  pre-pass (`handle_external_input_event` → `single_output_handling`) that ran
+  `ext_trans` *before* imminent models computed `output()` and could never
+  produce `con_trans`. They now flow through the shared two-phase tick: a model
+  that is both imminent and externally influenced at one instant correctly
+  fires `con_trans` (TSO/confluent), matching the HLA `step` path. The legacy
+  methods are retained (deprecated) for back-compat; a latent `msg[1]` indexing
+  bug in `single_output_handling` is fixed.
+
 ## [2.0.1] — 2026-05-06
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -10,10 +10,28 @@
 pyjevsim is a DEVS (discrete event system specification) modeling and
 simulation environment with built-in journaling. It supports snapshot
 and restore of individual models or the full simulation engine,
-virtual-time and real-time execution, and HLA federate integration via
-a stepped execution mode. Compatible with Python 3.10+.
+virtual-time and real-time execution, and HLA (IEEE 1516-2010) federate
+integration with pluggable RTI backends (including Pitch pRTI).
+Compatible with Python 3.10+.
 
 Full documentation: <https://pyjevsim.readthedocs.io/en/latest/>
+
+### What's new in 2.1
+
+- **Pluggable RTI backends.** A new `RTIConnector` interface
+  (`pyjevsim.hla`) lets any RTI drive a pyjevsim federate without
+  touching model code. A backend implements just two methods; direction
+  enforcement, FOM codec, callback dispatch and the join/resign state
+  machine are inherited. Ships an in-process bus (`inprocess`) for
+  multi-federate testing and a **Pitch pRTI** (IEEE 1516-2010) backend
+  (`pitch`, via JPype). Pick one by name with `create_rti(...)`.
+- **HLA ping-pong example** ([`examples/hla_pingpong/`](examples/hla_pingpong/)):
+  two federates (ping/pong) exchanging interactions and synchronizing an
+  object attribute — runnable offline (no Java) or against a live RTI.
+  Verified live against Pitch pRTI Free 5.5.2.
+- **Unified DEVS tick.** V_TIME, R_TIME and HLA_TIME now share one
+  two-phase tick body, so external events get correct confluent
+  (`con_trans`) semantics on every execution path.
 
 ### What's new in 2.0
 
@@ -56,6 +74,13 @@ the `dev` extra:
 
 ```
 pip install pyjevsim[dev]
+```
+
+The Pitch pRTI backend needs JPype, declared under the `hla-pitch` extra
+(the `loopback` / `inprocess` backends need nothing beyond the core):
+
+```
+pip install pyjevsim[hla-pitch]
 ```
 
 ## Quick Start
@@ -122,6 +147,10 @@ The [`examples/`](examples/) directory contains:
 - **`atsim/`** — anti-torpedo simulator with self-propelled and
   stationary decoy models.
 - **`mwmsim/`** — municipal waste management agent-based model.
+- **`hla_pingpong/`** — two HLA federates (ping/pong) demonstrating
+  federation join/resign, interaction exchange, and object-attribute
+  synchronization. Run offline (`run_inprocess.py`, no Java) or against a
+  live Pitch pRTI (`run_pitch.py`).
 
 ### Output messages are shared by reference
 
@@ -282,9 +311,62 @@ se.set_output_event_callback(lambda: print("output ready"))
 events = se.handle_external_output_event()
 ```
 
-## HLA/RTI Integration (HLA_TIME Mode)
+## HLA/RTI Integration
 
-For HLA/RTI-controlled simulations, use `HLA_TIME` mode with `step()` and `get_next_event_time()`.
+pyjevsim integrates with HLA (IEEE 1516-2010) at two levels: a high-level
+**pluggable RTI backend** layer (`pyjevsim.hla`) that runs ordinary DEVS
+models as federates, and the low-level `HLA_TIME` stepping hooks for
+custom federate ambassadors.
+
+### Pluggable RTI backends (`pyjevsim.hla`)
+
+Your `BehaviorModel` declares HLA *bindings* on its ports (an
+`HLAInteraction` or `HLAAttribute` per FOM id); an `HLAExecutorFactory`
+bridges those ports to a transport; and a `Federate` drives the
+time-advance loop. The transport is chosen by name — the same models run
+on any backend:
+
+```python
+from pyjevsim import SysExecutor, ExecutionType
+from pyjevsim.hla import (
+    create_rti, available_rtis, HLAExecutorFactory, HLAInteraction, Federate,
+)
+
+print(available_rtis())            # ['inprocess', 'loopback', 'pitch']
+
+transport = create_rti("inprocess")            # or "pitch" for live Pitch pRTI
+sys_exec = SysExecutor(1, ex_mode=ExecutionType.HLA_TIME)
+sys_exec.exec_factory = HLAExecutorFactory(
+    transport, {"chatter": {"out": HLAInteraction("Comm.Msg", direction="out")}}
+)
+sys_exec.register_entity(my_model)
+
+fed = Federate(sys_exec, transport)
+fed.join("MyFederation", "chatter", fom_paths=["Comm.xml"])
+fed.publish(HLAInteraction("Comm.Msg", direction="out"))
+fed.run_until(end_time=60.0, lookahead=1.0)
+fed.resign()
+```
+
+Built-in backends:
+
+| Name | Use | Dependency |
+|------|-----|------------|
+| `loopback` | self-mirror, single-federate unit tests | none |
+| `inprocess` | multi-federate in-process bus (tests/demos) | none |
+| `pitch` | **Pitch pRTI** IEEE 1516-2010, live federation | `pip install pyjevsim[hla-pitch]` + Java ≥ 9 + a running CRC |
+
+**Adding your own RTI** (CERTI, Portico, OpenRTI, MÄK, …): subclass
+`RTIConnector` and implement `_do_send` + `_do_request_time_advance`
+(plus optional lifecycle hooks), then `register_rti("name", factory)`.
+See [`docs/hla/rti_interface.md`](docs/hla/rti_interface.md) for the full
+guide and [`examples/hla_pingpong/`](examples/hla_pingpong/) for a
+working two-federate example.
+
+### Low-level stepping (`HLA_TIME` mode)
+
+If you prefer to wire pyjevsim into your own federate ambassador, use
+`HLA_TIME` mode directly with `step()` and `get_next_event_time()`.
 
 ```python
 se = SysExecutor(1, ex_mode=ExecutionType.HLA_TIME)
@@ -325,10 +407,13 @@ for the RTI.
 
 ### Federate ambassador
 
-pyjevsim ships the simulator-side hooks (above) but not an RTI
-ambassador. Wire `step` / `get_next_event_time` /
-`insert_external_event` / `set_output_event_callback` into the federate
-ambassador of your chosen IEEE 1516-2010 RTI client.
+pyjevsim ships a ready-made Pitch pRTI backend (above) and an
+`RTIConnector` interface for adding others. If instead you want to embed
+the simulator into an existing federate ambassador, wire `step` /
+`get_next_event_time` / `insert_external_event` /
+`set_output_event_callback` into the ambassador of your chosen IEEE
+1516-2010 RTI client directly — this is exactly what the `pitch` backend
+does internally.
 
 ## Graceful Termination
 

--- a/docs/hla/rti_interface.md
+++ b/docs/hla/rti_interface.md
@@ -1,0 +1,189 @@
+# pyjevsim — RTI-agnostic Interface
+
+This document describes the interface that lets **any** HLA/RTI implementation
+drive pyjevsim, and how to add a new backend (Pitch pRTI, CERTI, Portico,
+OpenRTI, MÄK, a custom gRPC/ZMQ surrogate, …).
+
+It extends the M0 contract in [`specification.md`](specification.md) §2. Where
+this document and the spec disagree on the *interface surface*, this document
+is authoritative; the spec remains authoritative on executor/federate
+semantics.
+
+## 1. Layering
+
+```
+ BehaviorModel (pure DEVS, no HLA imports)
+      │  output() / ext_trans() on named ports
+      ▼
+ HLAExecutor ── intercepts bound ports ──► RTIConnector.send(binding, payload, timestamp)
+      ▲                                          │  _codec.encode → _do_send  (RTI wire)
+      │  parent.insert_external_event            ▼
+ _HLARouter ◄── _emit(kind, fom_id, wire, ts) ── backend RX thread
+      │           _codec.decode
+      ▼
+ SysExecutor.step(granted)  ◄── Federate.run_until ──► RTIConnector.request_time_advance(target)
+```
+
+Four collaborating pieces, each independently replaceable:
+
+| Piece | Type | Replace to… |
+|-------|------|-------------|
+| `RTIConnector` | nominal base class (ABC) | support a different RTI |
+| `Codec`        | structural protocol      | map to a different FOM / encoding |
+| `RTICapabilities` | dataclass            | advertise what a backend can do |
+| registry       | name → factory           | select a backend by config string |
+
+## 2. `RTIConnector` — the extension point
+
+A backend subclasses `RTIConnector` and implements the **RTI-specific hooks**
+only. Everything else (direction enforcement, codec calls, single-callback
+dispatch, join/resign state machine, idempotent close) is inherited.
+
+### Required (abstract)
+
+```python
+def _do_send(self, binding, wire, timestamp) -> None
+def _do_request_time_advance(self, target: float) -> float   # returns granted
+```
+
+### Optional (default no-op — override if the RTI needs them)
+
+```python
+def _do_join(self, federation, federate_name, fom_paths) -> None
+def _do_publish(self, binding) -> None
+def _do_subscribe(self, binding) -> None
+def _do_resign(self) -> None
+def _do_close(self) -> None
+```
+
+### Provided by the base (do **not** re-implement)
+
+- `send(binding, payload, *, timestamp=None)` — drops `direction="in"`
+  bindings, runs `codec.encode`, calls `_do_send`.
+- `on_receive(cb)` — stores the single subscriber (the `_HLARouter`).
+- `_emit(kind, fom_id, wire, timestamp=None)` — **the backend RX hook**:
+  call it from your receive thread; it runs `codec.decode` and dispatches to
+  the callback. Thread-safe downstream (`insert_external_event` takes a lock).
+- `request_time_advance`, `join`, `publish`, `subscribe`, `resign`, `close`,
+  `joined` — public surface; they call the `_do_*` hooks and maintain state
+  (e.g. `publish` before `join` raises `RuntimeError`; `close` auto-resigns
+  and is idempotent).
+
+## 3. Adding a backend in 4 steps
+
+```python
+# my_rti.py
+from pyjevsim.hla import RTIConnector, RTICapabilities, register_rti
+
+class MyRTI(RTIConnector):
+    capabilities = RTICapabilities(
+        name="myrti", time_management=True, timestamp_ordered=True,
+        interactions=True, object_attributes=True, default_lookahead=1.0,
+    )
+
+    def __init__(self, codec=None, **opts):
+        super().__init__(codec)            # codec defaults to IdentityCodec
+        # ... open sockets / load the RTI client / start RX thread ...
+
+    # 1) outbound
+    def _do_send(self, binding, wire, timestamp):
+        # binding.kind in {"interaction","attribute"}, binding.fom_id is the
+        # FOM id, wire is codec-encoded. Ship it (sendInteraction / update...).
+        ...
+
+    # 2) time advance (block until granted; return granted logical time)
+    def _do_request_time_advance(self, target):
+        ...                                # e.g. timeAdvanceRequest + wait grant
+        return granted
+
+    # 3) lifecycle (only what you need)
+    def _do_join(self, federation, federate_name, fom_paths): ...
+    def _do_publish(self, binding): ...
+    def _do_subscribe(self, binding): ...
+    def _do_resign(self): ...
+    def _do_close(self): ...
+
+    # 4) inbound: from your RX thread, when data arrives, call:
+    #        self._emit(kind, fom_id, wire, timestamp)
+
+# register so apps can select it by name without importing the class
+register_rti("myrti", lambda **kw: MyRTI(**kw))
+```
+
+Use it without changing any model or executor code:
+
+```python
+from pyjevsim import SysExecutor, ExecutionType
+from pyjevsim.hla import create_rti, HLAExecutorFactory, Federate
+import my_rti  # noqa: F401  (registers "myrti")
+
+transport = create_rti("myrti", host="...", fom="Chat.xml")
+sys_exec  = SysExecutor(_time_resolution=1, ex_mode=ExecutionType.HLA_TIME)
+sys_exec.exec_factory = HLAExecutorFactory(transport, bindings_by_model)
+
+fed = Federate(sys_exec, transport)
+fed.join("MyFederation", "alice", fom_paths=["Chat.xml"])
+fed.run_until(end_time=60.0, lookahead=1.0)
+```
+
+## 4. Codec — FOM encoding is orthogonal
+
+`send`/`_emit` route the payload through a `Codec`:
+
+```python
+class Codec(Protocol):
+    def encode(self, binding, payload) -> Any   # payload is SysMessage.retrieve() (a list)
+    def decode(self, kind, fom_id, wire) -> Any
+```
+
+The default `IdentityCodec` passes objects through (in-process / loopback).
+A real RTI supplies a codec that maps to FOM datatypes — e.g. an HLA 1516e
+codec built on the `EncoderFactory` (`HLAfixedRecord`, `HLAinteger32BE`, …).
+Because the codec is injected (`MyRTI(codec=...)`), one FOM codec can be
+reused across RTIs, and one RTI can carry different FOMs.
+
+## 5. Capabilities — adapt or fail fast
+
+`RTICapabilities` lets callers branch on what a backend supports:
+
+| flag | meaning |
+|------|---------|
+| `time_management` | regulating/constrained TAR/NER available |
+| `timestamp_ordered` | TSO delivery (vs receive-order RO) |
+| `interactions` / `object_attributes` | interaction vs object-attribute classes |
+| `ddm` / `ownership` | data distribution / ownership management |
+| `default_lookahead` | suggested lookahead if the app doesn't set one |
+
+E.g. an app may refuse to use `HLAAttribute` bindings against a backend whose
+`object_attributes` is `False`, or skip passing timestamps when
+`timestamp_ordered` is `False`.
+
+## 6. Threading & time
+
+- **Outbound** runs on the simulation thread (inside `SysExecutor.step` →
+  `HLAExecutor.output` → `send`). Keep `_do_send` non-blocking where possible.
+- **Inbound** arrives on the backend's RX thread; `_emit` →
+  `insert_external_event` is lock-protected, so no extra locking is needed in
+  the model. Carry the **logical timestamp** through `_emit` so inbound events
+  land at the right simulated instant — pyjevsim's confluent/TSO tick
+  (`SysExecutor.step` / `_run_instant`) then delivers `con_trans` correctly
+  when an inbound event coincides with an imminent model.
+- **Time advance** is logical-only. `Federate.run_until` enforces
+  `lookahead > 0` and loops `request_time_advance(target)` → `step(granted)`
+  until `global_time >= end_time`. A backend may grant `≤ target`.
+
+## 7. Concrete backends (where they live)
+
+Backends register themselves on import so their dependencies stay optional:
+
+| RTI | how | dependency |
+|-----|-----|------------|
+| `loopback` | built-in (`transport.py`) | none |
+| Pitch pRTI 1516e | JPype in-process **or** Java/C++ surrogate over IPC | `jpype1` + `prti1516e.jar`, or a surrogate process |
+| CERTI | Python `rti1516e`/`hla` binding, or surrogate | CERTI libs |
+| Portico / OpenRTI / MÄK | C++/Java binding via JPype/JNI, or surrogate | vendor libs |
+
+See [`instruction.md`](instruction.md) §7 for the kdx-rti migration notes and
+the Pitch-specific surrogate vs. in-process JPype trade-off discussed in the
+project history.
+```

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,8 +12,8 @@ sys.path.insert(0, os.path.abspath('../..'))
 project = 'pyjevsim'
 author = 'Changbeom Choi'
 copyright = '2024-2026, Changbeom Choi'
-version = '2.0.0'
-release = '2.0.0'
+version = '2.1.0'
+release = '2.1.0'
 
 extensions = [
     'sphinx.ext.autodoc',      

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,11 +9,29 @@ PyJEvSim documentation
 PyJEvSim is a DEVS (Discrete Event System Specification) modeling and
 simulation environment with built-in journaling. It supports snapshot and
 restore of individual models or the full simulation engine, virtual-time
-and real-time execution, and an HLA-friendly stepped execution mode for
-federate integration.
+and real-time execution, and HLA (IEEE 1516-2010) federate integration
+with pluggable RTI backends (including Pitch pRTI).
 
   - GitHub: `eventsim/pyjevsim <https://github.com/eventsim/pyjevsim>`_
   - PyPI: `pyjevsim <https://pypi.org/project/pyjevsim/>`_
+
+What's new in 2.1
+-----------------
+
+- **Pluggable RTI backends.** A new ``RTIConnector`` interface
+  (``pyjevsim.hla``) lets any RTI drive a pyjevsim federate without
+  touching model code. A backend implements just ``_do_send`` and
+  ``_do_request_time_advance``; direction enforcement, FOM codec,
+  callback dispatch and the join/resign state machine are inherited.
+  Ships an in-process bus (``inprocess``) and a **Pitch pRTI**
+  (IEEE 1516-2010) backend (``pitch``, via JPype). Select by name with
+  ``create_rti(...)``. See :doc:`pyjevsim_hla`.
+- **HLA ping-pong example** under ``examples/hla_pingpong/``: two
+  federates exchanging interactions and synchronizing an object
+  attribute, runnable offline or against a live RTI.
+- **Unified DEVS tick.** ``V_TIME``, ``R_TIME`` and ``HLA_TIME`` share a
+  single two-phase tick body, so external events get correct confluent
+  (``con_trans``) semantics on every path.
 
 What's new in 2.0
 -----------------
@@ -77,3 +95,4 @@ Quick Start Guides
 
    pyjevsim_quick_start
    snapshot_quick_start
+   pyjevsim_hla

--- a/docs/source/pyjevsim_hla.rst
+++ b/docs/source/pyjevsim_hla.rst
@@ -1,0 +1,158 @@
+HLA / RTI Integration
+=====================
+
+pyjevsim runs ordinary DEVS models as HLA (IEEE 1516-2010) federates. The
+model code stays pure DEVS; what changes is the *factory* that wraps each
+model and the *transport* (RTI backend) it talks to. The same model runs
+unchanged in a standalone simulation, on the in-process test bus, or
+against a live RTI such as Pitch pRTI.
+
+Architecture
+------------
+
+::
+
+   BehaviorModel (pure DEVS)
+        |  output()/ext_trans() on named ports
+        v
+   HLAExecutor ---- intercepts bound ports ----> RTIConnector.send(...)
+        ^                                              |  codec.encode -> _do_send
+        |  insert_external_event                       v
+   _HLARouter <---- _emit(kind, fom_id, ...) ---- backend RX thread
+        |
+        v
+   SysExecutor.step(granted)  <-- Federate.run_until --> request_time_advance
+
+Four replaceable pieces live in ``pyjevsim.hla``:
+
+``RTIConnector``
+   Base class for RTI backends. A backend implements only the
+   RTI-specific hooks; the common plumbing is inherited.
+``Codec`` / ``IdentityCodec``
+   FOM (de)serialization, decoupled from the wire transport.
+``RTICapabilities``
+   Feature flags a backend advertises (time management, TSO, object
+   attributes, ...).
+registry
+   ``register_rti`` / ``create_rti`` / ``available_rtis`` select a
+   backend by name.
+
+Built-in backends
+-----------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 18 42 40
+
+   * - Name
+     - Use
+     - Dependency
+   * - ``loopback``
+     - self-mirror, single-federate unit tests
+     - none
+   * - ``inprocess``
+     - multi-federate in-process bus (tests/demos)
+     - none
+   * - ``pitch``
+     - Pitch pRTI (IEEE 1516-2010), live federation
+     - ``pip install pyjevsim[hla-pitch]`` + Java >= 9 + a running CRC
+
+Turning a model into a federate
+-------------------------------
+
+.. code-block:: python
+
+   from pyjevsim import SysExecutor, ExecutionType
+   from pyjevsim.hla import (
+       create_rti, HLAExecutorFactory, HLAInteraction, HLAAttribute, Federate,
+   )
+
+   # 1. Declare bindings: model port -> FOM identifier.
+   bindings = {
+       "out_msg": HLAInteraction("Comm.ChatMsg", direction="out"),
+       "in_msg":  HLAInteraction("Comm.ChatMsg", direction="in"),
+   }
+
+   # 2. Pick a transport by name (models are backend-agnostic).
+   transport = create_rti("inprocess")          # or "pitch", ...
+
+   # 3. Wire the HLA factory and register the model.
+   sys_exec = SysExecutor(1, ex_mode=ExecutionType.HLA_TIME)
+   sys_exec.exec_factory = HLAExecutorFactory(transport, {"chatter": bindings})
+   sys_exec.register_entity(my_model)           # my_model.get_name() == "chatter"
+
+   # 4. Drive the federate.
+   fed = Federate(sys_exec, transport)
+   fed.join("MyFederation", "chatter", fom_paths=["Comm.xml"])
+   fed.publish(bindings["out_msg"])
+   fed.subscribe(bindings["in_msg"])
+   fed.run_until(end_time=60.0, lookahead=1.0)
+   fed.resign()
+
+Object attributes use ``HLAAttribute`` instead of ``HLAInteraction``;
+an outbound attribute additionally needs ``object_class``.
+
+Adding a new RTI backend
+------------------------
+
+Subclass ``RTIConnector`` and implement the two abstract hooks (plus any
+lifecycle hooks the RTI needs); call ``_emit`` from the receive path:
+
+.. code-block:: python
+
+   from pyjevsim.hla import RTIConnector, RTICapabilities, register_rti
+
+   class MyRTI(RTIConnector):
+       capabilities = RTICapabilities(name="myrti", time_management=True,
+                                      timestamp_ordered=True)
+
+       def _do_send(self, binding, wire, timestamp):
+           ...  # ship to the RTI (sendInteraction / updateAttributeValues)
+
+       def _do_request_time_advance(self, target):
+           ...  # block until granted; return the granted logical time
+
+       # optional: _do_join / _do_publish / _do_subscribe / _do_resign / _do_close
+       # inbound: from your RX thread call self._emit(kind, fom_id, wire, timestamp)
+
+   register_rti("myrti", lambda **kw: MyRTI(**kw))
+
+The connector supplies direction enforcement, ``codec`` encode/decode,
+single-callback dispatch, the join/resign state machine, and idempotent
+close. Full guide: ``docs/hla/rti_interface.md`` in the repository.
+
+Ping-pong example
+-----------------
+
+``examples/hla_pingpong/`` contains two federates (``ping`` / ``pong``)
+that rally a ball via interactions while synchronizing an object
+attribute. Run it offline (no Java)::
+
+   python examples/hla_pingpong/run_inprocess.py
+
+or against a live Pitch pRTI (``pitch`` backend, with a CRC running)::
+
+   python examples/hla_pingpong/run_pitch.py
+
+Low-level stepping
+------------------
+
+To embed pyjevsim in your own federate ambassador instead of using a
+backend, drive ``HLA_TIME`` mode directly:
+
+.. code-block:: python
+
+   se = SysExecutor(1, ex_mode=ExecutionType.HLA_TIME)
+   se.register_entity(model)
+   se.init_sim()
+   while not se.is_terminated():
+       next_t = se.get_next_event_time()          # compute Time Advance Request
+       granted = ...                              # wait for the RTI grant
+       output_events = se.step(granted)           # process events <= granted
+       # ... publish output_events to the RTI ...
+
+``step(granted_time)`` runs the same two-phase Parallel-DEVS tick as the
+V_TIME path (correct ``int`` / ``ext`` / ``con`` transitions, multi-round
+sigma=0 cascades in one call) and returns the output events drained
+during the grant. This is exactly what the ``pitch`` backend uses
+internally.

--- a/examples/hla_pingpong/README.md
+++ b/examples/hla_pingpong/README.md
@@ -1,0 +1,87 @@
+# HLA Ping-Pong example
+
+Two federates, **ping** and **pong**, rally a ball across an HLA federation:
+
+- `ping` serves at t=0 and returns each `Pong` it receives, up to `max_volleys`.
+- `pong` returns every `Ping`.
+- `ping` also publishes an object attribute (`PingPaddle.hits`) that `pong`
+  reflects — demonstrating **object synchronization** alongside the
+  **interaction** rally.
+
+The DEVS models ([`pingpong_models.py`](pingpong_models.py)) are
+**RTI-agnostic**: the exact same classes run on the in-process bus and on real
+Pitch pRTI. Only the transport (chosen via `create_rti(...)`) changes.
+
+## Files
+
+| File | What |
+|------|------|
+| `pingpong_models.py` | `Ping` / `Pong` models + HLA bindings + Pitch FOM map |
+| `fom/PingPong.xml` | IEEE 1516-2010 FOM (interactions `Ping`/`Pong`, object `PingPaddle`) |
+| `run_inprocess.py` | Offline demo — two federates over `InProcessRTI` (no Java) |
+| `run_pitch.py` | Live demo — two federates over Pitch pRTI (`pitch` backend) |
+
+## Run offline (no Java / RTI needed)
+
+```bash
+python examples/hla_pingpong/run_inprocess.py
+```
+
+Expected:
+
+```
+federation members after join: 2
+pong received pings: [0, 1, 2, 3]
+ping received pongs: [0, 1, 2, 3]
+pong reflected hits (object sync): [0, 1, 2, 3]
+federation members after resign: 0
+```
+
+## Run against Pitch pRTI
+
+> Verified live against **Pitch pRTI Free 5.5.2** with **Temurin 11** —
+> produces the same rally as the offline demo:
+> `pong received pings: [0, 1, 2, 3]`, `ping received pongs: [0, 1, 2, 3]`,
+> `pong reflected hits: [0, 1, 2, 3]`.
+
+Prerequisites:
+
+1. `pip install jpype1` — must match your Python **and** Java. JPype ≥ 1.6
+   requires **Java ≥ 9**; for Java 8 pin `jpype1<=1.5`.
+2. Pitch pRTI installed and a **CRC running**.
+3. `PRTI_HOME` set (default `C:\Program Files\prti1516e`). Optionally
+   `PYJEVSIM_JVM` to point at a specific `jvm.dll` (use a Java ≥ 9 runtime).
+
+```bash
+python examples/hla_pingpong/run_pitch.py
+```
+
+Switching backend is the only change — the models and wiring are identical:
+
+```python
+# offline
+tx = create_rti("inprocess", federation=shared_bus)
+# pitch
+tx = create_rti("pitch", federation="PingPong", federate="ping",
+                fom="fom/PingPong.xml", fom_map=PINGPONG_FOM_MAP,
+                classpath=[r"...\\prti1516e.jar"], lookahead=1.0)
+```
+
+## Tests
+
+- `tests/hla/test_pingpong.py` — always runs; verifies join/resign,
+  interaction exchange (both directions) and object sync deterministically
+  over the in-process bus.
+- `tests/hla/test_pitch_backend.py` — guarded; runs the encoder round-trip
+  when JPype + Java ≥ 9 + `prti1516e.jar` are present, and the full live
+  federation when `PYJEVSIM_PITCH_LIVE=1` with a running CRC. Skips otherwise.
+
+## How it maps to HLA
+
+| pyjevsim | HLA / pRTI |
+|----------|-----------|
+| `HLAInteraction("PingPong.Ping", "out")` on a port | `publishInteractionClass` + `sendInteraction` |
+| `HLAInteraction("PingPong.Pong", "in")` on a port | `subscribeInteractionClass` + `receiveInteraction` |
+| `HLAAttribute("PingPaddle.hits", "out", object_class=...)` | `registerObjectInstance` + `updateAttributeValues` |
+| `HLAAttribute("PingPaddle.hits", "in")` | `subscribeObjectClassAttributes` + `reflectAttributeValues` |
+| `Federate.run_until` / `SysExecutor.step` | `timeAdvanceRequest` ↔ `timeAdvanceGrant` |

--- a/examples/hla_pingpong/fom/PingPong.xml
+++ b/examples/hla_pingpong/fom/PingPong.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<objectModel xmlns="http://standards.ieee.org/IEEE1516-2010">
+  <modelIdentification>
+    <name>PingPong</name>
+    <type>FOM</type>
+    <version>1.0</version>
+    <purpose>Minimal ping-pong FOM for the pyjevsim HLA example.</purpose>
+  </modelIdentification>
+
+  <objects>
+    <objectClass>
+      <name>HLAobjectRoot</name>
+      <objectClass>
+        <name>PingPaddle</name>
+        <sharing>PublishSubscribe</sharing>
+        <attribute>
+          <name>hits</name>
+          <dataType>HLAinteger32BE</dataType>
+          <updateType>Conditional</updateType>
+          <ownership>NoTransfer</ownership>
+          <sharing>PublishSubscribe</sharing>
+          <transportation>HLAreliable</transportation>
+          <order>TimeStamp</order>
+        </attribute>
+      </objectClass>
+    </objectClass>
+  </objects>
+
+  <interactions>
+    <interactionClass>
+      <name>HLAinteractionRoot</name>
+      <interactionClass>
+        <name>Ping</name>
+        <sharing>PublishSubscribe</sharing>
+        <transportation>HLAreliable</transportation>
+        <order>TimeStamp</order>
+        <parameter>
+          <name>count</name>
+          <dataType>HLAinteger32BE</dataType>
+        </parameter>
+        <parameter>
+          <name>sender</name>
+          <dataType>HLAunicodeString</dataType>
+        </parameter>
+      </interactionClass>
+      <interactionClass>
+        <name>Pong</name>
+        <sharing>PublishSubscribe</sharing>
+        <transportation>HLAreliable</transportation>
+        <order>TimeStamp</order>
+        <parameter>
+          <name>count</name>
+          <dataType>HLAinteger32BE</dataType>
+        </parameter>
+        <parameter>
+          <name>sender</name>
+          <dataType>HLAunicodeString</dataType>
+        </parameter>
+      </interactionClass>
+    </interactionClass>
+  </interactions>
+
+  <switches>
+    <autoProvide isEnabled="false"/>
+    <conveyRegionDesignatorSets isEnabled="false"/>
+    <conveyProducingFederate isEnabled="false"/>
+    <attributeScopeAdvisory isEnabled="false"/>
+    <attributeRelevanceAdvisory isEnabled="false"/>
+    <objectClassRelevanceAdvisory isEnabled="false"/>
+    <interactionRelevanceAdvisory isEnabled="false"/>
+    <serviceReporting isEnabled="false"/>
+    <exceptionReporting isEnabled="false"/>
+    <delaySubscriptionEvaluation isEnabled="false"/>
+    <automaticResignAction resignAction="CancelThenDeleteThenDivest"/>
+  </switches>
+</objectModel>

--- a/examples/hla_pingpong/pingpong_models.py
+++ b/examples/hla_pingpong/pingpong_models.py
@@ -1,0 +1,131 @@
+"""Ping-pong federate models + HLA bindings (RTI-agnostic).
+
+Two paddles rally a ball:
+
+  * ``Ping`` serves at t=0, then returns every ``Pong`` it receives, until
+    ``max_volleys`` is reached.
+  * ``Pong`` returns every ``Ping`` it receives.
+
+Three FOM endpoints exercise the two HLA data paths:
+
+  * ``PingPong.Ping`` / ``PingPong.Pong`` — **interactions** (the rally).
+  * ``PingPaddle.hits`` — an **object attribute** Ping publishes and Pong
+    reflects (object synchronization).
+
+The models import nothing RTI-specific beyond the binding dataclasses; the
+exact same classes run on ``inprocess``, ``loopback`` or ``pitch``.
+"""
+
+from __future__ import annotations
+
+from pyjevsim import BehaviorModel, SysMessage
+from pyjevsim.hla import HLAAttribute, HLAInteraction
+
+PING_FOM = "PingPong.Ping"
+PONG_FOM = "PingPong.Pong"
+HITS_FOM = "PingPaddle.hits"
+
+
+class Ping(BehaviorModel):
+    """Server paddle: serves once, then returns each pong up to max_volleys."""
+
+    def __init__(self, name: str = "ping", max_volleys: int = 3,
+                 period: float = 1.0):
+        super().__init__(name)
+        self.insert_state("serve", 0)        # serve immediately at t=0
+        self.insert_state("rally", period)   # return `period` after a pong
+        self.insert_state("idle")            # Infinite — passive
+        self.init_state("serve")
+        self.insert_input_port("in_pong")
+        self.insert_output_port("out_ping")
+        self.insert_output_port("out_hits")
+        self.max_volleys = max_volleys
+        self.count = 0                       # current ball number
+        self.received_pongs: list = []
+
+    def ext_trans(self, port, msg):
+        if port == "in_pong":
+            # Inbound contract: retrieve()[0] is the peer's full
+            # retrieve() list; our payload is its single dict.
+            data = msg.retrieve()[0][0]
+            self.received_pongs.append(data)
+            self.count = int(data["count"]) + 1
+            self._cur_state = "rally" if self.count <= self.max_volleys else "idle"
+
+    def int_trans(self):
+        if self._cur_state in ("serve", "rally"):
+            self._cur_state = "idle"
+
+    def output(self, deliver):
+        if self._cur_state in ("serve", "rally"):
+            ball = SysMessage(self.get_name(), "out_ping")
+            ball.insert({"count": self.count, "sender": self.get_name()})
+            deliver.insert_message(ball)
+            # Object attribute: publish how many balls this paddle has hit.
+            hits = SysMessage(self.get_name(), "out_hits")
+            hits.insert({"hits": self.count})
+            deliver.insert_message(hits)
+
+
+class Pong(BehaviorModel):
+    """Responder paddle: returns every ping; reflects Ping's hits attribute."""
+
+    def __init__(self, name: str = "pong", period: float = 1.0):
+        super().__init__(name)
+        self.insert_state("wait")            # Infinite — passive
+        self.insert_state("return", period)
+        self.init_state("wait")
+        self.insert_input_port("in_ping")
+        self.insert_input_port("in_hits")
+        self.insert_output_port("out_pong")
+        self.count = 0
+        self.received_pings: list = []
+        self.reflected_hits: list = []       # object-sync observations
+
+    def ext_trans(self, port, msg):
+        if port == "in_ping":
+            data = msg.retrieve()[0][0]
+            self.received_pings.append(data)
+            self.count = int(data["count"])
+            self._cur_state = "return"
+        elif port == "in_hits":
+            data = msg.retrieve()[0][0]
+            self.reflected_hits.append(int(data["hits"]))
+
+    def int_trans(self):
+        if self._cur_state == "return":
+            self._cur_state = "wait"
+
+    def output(self, deliver):
+        if self._cur_state == "return":
+            ball = SysMessage(self.get_name(), "out_pong")
+            ball.insert({"count": self.count, "sender": self.get_name()})
+            deliver.insert_message(ball)
+
+
+def ping_bindings() -> dict:
+    return {
+        "out_ping": HLAInteraction(PING_FOM, direction="out"),
+        "in_pong": HLAInteraction(PONG_FOM, direction="in"),
+        "out_hits": HLAAttribute(HITS_FOM, direction="out",
+                                 object_class="PingPaddle"),
+    }
+
+
+def pong_bindings() -> dict:
+    return {
+        "in_ping": HLAInteraction(PING_FOM, direction="in"),
+        "out_pong": HLAInteraction(PONG_FOM, direction="out"),
+        "in_hits": HLAAttribute(HITS_FOM, direction="in"),
+    }
+
+
+# FOM map for the Pitch backend (handle resolution + field encoding).
+PINGPONG_FOM_MAP = {
+    PING_FOM: {"kind": "interaction", "class": "HLAinteractionRoot.Ping",
+               "fields": {"count": "int32", "sender": "string"}},
+    PONG_FOM: {"kind": "interaction", "class": "HLAinteractionRoot.Pong",
+               "fields": {"count": "int32", "sender": "string"}},
+    HITS_FOM: {"kind": "attribute", "class": "HLAobjectRoot.PingPaddle",
+               "fields": {"hits": "int32"}},
+}

--- a/examples/hla_pingpong/run_inprocess.py
+++ b/examples/hla_pingpong/run_inprocess.py
@@ -1,0 +1,83 @@
+"""Offline ping-pong demo — two federates over the in-process RTI bus.
+
+No Java / pRTI required. Two separate SysExecutor federates (``ping`` and
+``pong``) join one :class:`InProcessFederation` and rally a ball via HLA
+interactions, while Ping's ``hits`` object attribute is reflected by Pong.
+
+Run:  python examples/hla_pingpong/run_inprocess.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+# Prefer the dev source tree over any installed pyjevsim wheel.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+sys.path.insert(0, os.path.dirname(__file__))
+
+from pingpong_models import Ping, Pong, ping_bindings, pong_bindings  # noqa: E402
+
+from pyjevsim import ExecutionType, SysExecutor  # noqa: E402
+from pyjevsim.hla import (  # noqa: E402
+    Federate,
+    HLAExecutorFactory,
+    InProcessFederation,
+    InProcessRTI,
+)
+
+FOM = os.path.join(os.path.dirname(__file__), "fom", "PingPong.xml")
+
+
+def build_federate(model, bindings, model_name, federation):
+    se = SysExecutor(_time_resolution=1, ex_mode=ExecutionType.HLA_TIME)
+    transport = InProcessRTI(federation=federation)
+    se.exec_factory = HLAExecutorFactory(transport, {model_name: bindings})
+    se.register_entity(model)
+    se.init_sim()
+    fed = Federate(se, transport)
+    return se, transport, fed
+
+
+def main(max_volleys: int = 3, rounds: int = 8) -> None:
+    federation = InProcessFederation("PingPong")
+
+    ping_se, ping_tx, ping_fed = build_federate(
+        Ping("ping", max_volleys=max_volleys), ping_bindings(), "ping", federation
+    )
+    pong_se, pong_tx, pong_fed = build_federate(
+        Pong("pong"), pong_bindings(), "pong", federation
+    )
+
+    # join + publish/subscribe each federate
+    for fed, name, binds in (
+        (ping_fed, "ping", ping_bindings()),
+        (pong_fed, "pong", pong_bindings()),
+    ):
+        fed.join("PingPong", name, fom_paths=[FOM])
+        for b in binds.values():
+            if b.direction in ("out", "inout"):
+                fed.publish(b)
+            if b.direction in ("in", "inout"):
+                fed.subscribe(b)
+
+    print(f"federation members after join: {len(federation.members)}")
+
+    # Coordinated lock-step advance (the in-process bus does no time mgmt).
+    for t in range(1, rounds + 1):
+        ping_se.step(t)
+        pong_se.step(t)
+
+    ping = ping_se.get_entity("ping")[0].get_core_model()
+    pong = pong_se.get_entity("pong")[0].get_core_model()
+    print("pong received pings:", [d["count"] for d in pong.received_pings])
+    print("ping received pongs:", [d["count"] for d in ping.received_pongs])
+    print("pong reflected hits (object sync):", pong.reflected_hits)
+
+    ping_fed.resign()
+    pong_fed.resign()
+    print(f"federation members after resign: {len(federation.members)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/hla_pingpong/run_pitch.py
+++ b/examples/hla_pingpong/run_pitch.py
@@ -1,0 +1,93 @@
+"""Live ping-pong against Pitch pRTI (IEEE 1516-2010).
+
+Runs the SAME models as run_inprocess.py, but each paddle is a real federate
+joined to a real Pitch federation via the ``pitch`` backend (JPype +
+prti1516e). Both federates run in this one process for simplicity; in a real
+deployment each would be its own process/host.
+
+Prerequisites:
+  * pip install jpype1   (matching your Python; JPype>=1.6 needs Java>=9)
+  * Pitch pRTI installed; a CRC running.
+  * PRTI_HOME pointing at the install (default: C:\\Program Files\\prti1516e).
+
+Run:  python examples/hla_pingpong/run_pitch.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+sys.path.insert(0, os.path.dirname(__file__))
+
+from pingpong_models import (  # noqa: E402
+    PINGPONG_FOM_MAP,
+    Ping,
+    Pong,
+    ping_bindings,
+    pong_bindings,
+)
+
+from pyjevsim import ExecutionType, SysExecutor  # noqa: E402
+from pyjevsim.hla import Federate, HLAExecutorFactory, create_rti  # noqa: E402
+
+PRTI_HOME = os.environ.get("PRTI_HOME", r"C:\Program Files\prti1516e")
+JAR = os.path.join(PRTI_HOME, "lib", "prti1516e.jar")
+FOM = os.path.join(os.path.dirname(__file__), "fom", "PingPong.xml")
+# Optional explicit JVM (use a Java>=9 runtime for JPype>=1.6):
+JVM_PATH = os.environ.get("PYJEVSIM_JVM")  # e.g. .../jre/bin/server/jvm.dll
+
+
+def build(model, bindings, name):
+    se = SysExecutor(_time_resolution=1, ex_mode=ExecutionType.HLA_TIME)
+    tx = create_rti(
+        "pitch",
+        federation="PingPong", federate=name,
+        fom=FOM, fom_map=PINGPONG_FOM_MAP,
+        jvm_path=JVM_PATH, classpath=[JAR], lookahead=1.0,
+    )
+    se.exec_factory = HLAExecutorFactory(tx, {name: bindings})
+    se.register_entity(model)
+    se.init_sim()
+    return se, Federate(se, tx)
+
+
+def main(max_volleys: int = 3, end_time: float = 25.0, lookahead: float = 1.0) -> None:
+    import threading
+
+    ping_se, ping_fed = build(Ping("ping", max_volleys=max_volleys),
+                              ping_bindings(), "ping")
+    pong_se, pong_fed = build(Pong("pong"), pong_bindings(), "pong")
+
+    for fed, name, binds in ((ping_fed, "ping", ping_bindings()),
+                             (pong_fed, "pong", pong_bindings())):
+        fed.join("PingPong", name, fom_paths=[FOM])
+        for b in binds.values():
+            if b.direction in ("out", "inout"):
+                fed.publish(b)
+            if b.direction in ("in", "inout"):
+                fed.subscribe(b)
+        print(f"{name}: joined + published/subscribed")
+
+    # Two time-managed federates must advance in tandem (each is both
+    # regulating and constrained), so each runs in its own thread; the RTI
+    # coordinates their time-advance grants and delivers TSO messages.
+    t_ping = threading.Thread(target=ping_fed.run_until, args=(end_time, lookahead))
+    t_pong = threading.Thread(target=pong_fed.run_until, args=(end_time, lookahead))
+    t_ping.start(); t_pong.start()
+    t_ping.join(); t_pong.join()
+
+    pong = pong_se.get_entity("pong")[0].get_core_model()
+    ping = ping_se.get_entity("ping")[0].get_core_model()
+    print("pong received pings:", [d["count"] for d in pong.received_pings])
+    print("ping received pongs:", [d["count"] for d in ping.received_pongs])
+    print("pong reflected hits:", pong.reflected_hits)
+
+    ping_fed.resign()
+    pong_fed.resign()
+    print("both federates resigned")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyjevsim/hla/__init__.py
+++ b/pyjevsim/hla/__init__.py
@@ -2,22 +2,52 @@
 
 Decorates BehaviorExecutor with output-to-RTI / RTI-to-input bridging,
 keeping BehaviorModel pure DEVS. See docs/hla/specification.md for the
-contract and docs/hla/instruction.md for the developer guide.
+contract, docs/hla/instruction.md for the developer guide, and
+docs/hla/rti_interface.md for how to add a new RTI backend.
 """
 
 from .bindings import HLAAttribute, HLAInteraction
 from .factory import HLAExecutorFactory
 from .federate import Federate
 from .hla_executor import HLAExecutor
-from .transport import LoopbackTransport, Transport, _HLARouter
+from .registry import (
+    available_rtis,
+    create_rti,
+    register_rti,
+    unregister_rti,
+)
+from .transport import (
+    Codec,
+    IdentityCodec,
+    LoopbackTransport,
+    RTICapabilities,
+    RTIConnector,
+    Transport,
+    _HLARouter,
+)
+
+# Importing the backends package registers the built-in RTI backends
+# ("inprocess" always; "pitch" lazily). Kept last to avoid import cycles.
+from . import backends  # noqa: E402,F401
+from .backends.inprocess import InProcessFederation, InProcessRTI  # noqa: E402
 
 __all__ = [
+    "Codec",
     "Federate",
     "HLAAttribute",
     "HLAExecutor",
     "HLAExecutorFactory",
     "HLAInteraction",
+    "IdentityCodec",
+    "InProcessFederation",
+    "InProcessRTI",
     "LoopbackTransport",
+    "RTICapabilities",
+    "RTIConnector",
     "Transport",
     "_HLARouter",
+    "available_rtis",
+    "create_rti",
+    "register_rti",
+    "unregister_rti",
 ]

--- a/pyjevsim/hla/backends/__init__.py
+++ b/pyjevsim/hla/backends/__init__.py
@@ -1,0 +1,11 @@
+"""RTI backend implementations.
+
+Importing this package registers the always-available ``inprocess`` backend
+and the optional ``pitch`` backend. ``pitch`` self-registers but imports its
+heavy dependency (JPype + prti1516e) lazily, so importing this package never
+fails even when JPype / Java / pRTI are absent — the error surfaces only when
+``create_rti("pitch", ...)`` actually tries to boot the JVM.
+"""
+
+from . import inprocess  # noqa: F401  registers "inprocess"
+from . import pitch      # noqa: F401  registers "pitch" (lazy deps)

--- a/pyjevsim/hla/backends/inprocess.py
+++ b/pyjevsim/hla/backends/inprocess.py
@@ -1,0 +1,98 @@
+"""InProcessRTI — a multi-federate, in-process stand-in for an RTI.
+
+Unlike :class:`~pyjevsim.hla.transport.LoopbackTransport` (which mirrors a
+single connector's output straight back to itself), ``InProcessRTI`` attaches
+multiple connectors to a shared :class:`InProcessFederation` bus. A ``send``
+from one connector is delivered to *every other* attached connector, exactly
+like a real federation — so two separate ``SysExecutor`` federates (e.g. ping
+and pong) can exchange interactions and object-attribute updates in one
+process, with no Java/RTI required.
+
+Subscription filtering is still done per-connector by the ``_HLARouter``, so
+each federate only sees the ``(kind, fom_id)`` pairs it subscribed to.
+
+Registered under the name ``"inprocess"``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..registry import register_rti
+from ..transport import RTICapabilities, RTIConnector
+
+
+class InProcessFederation:
+    """Shared bus standing in for a federation execution.
+
+    Connectors attach on ``join`` and detach on ``resign``/``close``. The
+    bus broadcasts each send to every *other* attached connector.
+    """
+
+    def __init__(self, name: str = "default") -> None:
+        self.name = name
+        self._members: list = []
+
+    @property
+    def members(self) -> tuple:
+        return tuple(self._members)
+
+    def attach(self, conn) -> None:
+        if conn not in self._members:
+            self._members.append(conn)
+
+    def detach(self, conn) -> None:
+        if conn in self._members:
+            self._members.remove(conn)
+
+    def broadcast(self, sender, kind: str, fom_id: str, wire: Any,
+                  timestamp: "float | None") -> None:
+        # Snapshot so a callback that resigns mid-dispatch can't mutate the
+        # list under iteration.
+        for m in tuple(self._members):
+            if m is not sender:
+                m._emit(kind, fom_id, wire, timestamp)
+
+
+class InProcessRTI(RTIConnector):
+    """In-process connector attached to an :class:`InProcessFederation`."""
+
+    capabilities = RTICapabilities(
+        name="inprocess",
+        time_management=True,
+        timestamp_ordered=True,
+        interactions=True,
+        object_attributes=True,
+    )
+
+    def __init__(self, federation: "InProcessFederation | None" = None,
+                 codec=None, **_ignored) -> None:
+        super().__init__(codec)
+        self._fed = federation if federation is not None else InProcessFederation()
+
+    @property
+    def federation(self) -> InProcessFederation:
+        return self._fed
+
+    # --- RTI-specific hooks -------------------------------------------------
+
+    def _do_send(self, binding, wire: Any, timestamp: "float | None") -> None:
+        self._fed.broadcast(self, binding.kind, binding.fom_id, wire, timestamp)
+
+    def _do_request_time_advance(self, target: float) -> float:
+        # No global time coordination in-process: identity grant. Callers
+        # that need lock-step semantics drive each federate's `step()`
+        # explicitly (see examples/hla_pingpong).
+        return target
+
+    def _do_join(self, federation: str, federate_name: str, fom_paths) -> None:
+        self._fed.attach(self)
+
+    def _do_resign(self) -> None:
+        self._fed.detach(self)
+
+    def _do_close(self) -> None:
+        self._fed.detach(self)
+
+
+register_rti("inprocess", lambda **kw: InProcessRTI(**kw))

--- a/pyjevsim/hla/backends/pitch.py
+++ b/pyjevsim/hla/backends/pitch.py
@@ -1,0 +1,400 @@
+"""PitchTransport — IEEE 1516-2010 backend for Pitch pRTI via JPype.
+
+Drives a pyjevsim federate against a real Pitch pRTI (``prti1516e.jar``) by
+loading the RTI's Java API in-process with JPype. Implements the
+:class:`~pyjevsim.hla.transport.RTIConnector` contract so the same DEVS models
+that run on ``loopback`` / ``inprocess`` run unchanged against Pitch.
+
+Registered (lazily) under the name ``"pitch"``::
+
+    from pyjevsim.hla import create_rti
+    tx = create_rti("pitch",
+                    federation="PingPong",
+                    federate="ping",
+                    fom="examples/hla_pingpong/fom/PingPong.xml",
+                    fom_map=PINGPONG_FOM_MAP,
+                    jvm_path=r"C:\\Program Files\\...\\jvm.dll",   # optional
+                    classpath=[r"C:\\Program Files\\prti1516e\\lib\\prti1516e.jar"])
+
+Requirements (NOT needed to import this module — only to *use* it):
+  * ``pip install jpype1`` matching your Python and Java versions
+    (JPype >= 1.6 needs Java 9+; for Java 8 pin ``jpype1<=1.5``).
+  * Pitch pRTI installed; its ``prti1516e.jar`` on the classpath.
+  * A running CRC (Central RTI Component) to ``connect``/``join``.
+
+``fom_map`` describes how each FOM id maps to interaction/object classes and
+their field datatypes, so the transport can resolve handles and encode/decode
+with the RTI's ``EncoderFactory``::
+
+    PINGPONG_FOM_MAP = {
+        "PingPong.Ping":   {"kind": "interaction",
+                            "class": "HLAinteractionRoot.Ping",
+                            "fields": {"count": "int32", "sender": "string"}},
+        "PingPaddle.hits": {"kind": "attribute",
+                            "class": "HLAobjectRoot.PingPaddle",
+                            "fields": {"hits": "int32"}},
+    }
+
+This module is a reference implementation: it targets the prti1516e API
+surface but, because a live RTI + matching JVM are required, it is exercised
+by the guarded tests in ``tests/hla/test_pitch_backend.py`` (skipped when the
+toolchain is absent), while the protocol-level ping-pong logic is verified
+deterministically against ``InProcessRTI``.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+from ..registry import register_rti
+from ..transport import RTICapabilities, RTIConnector
+
+
+# --------------------------------------------------------------- field codec
+
+
+def _encode_field(ef, datatype: str, value: Any):
+    """Encode one Python value to an HLA byte[] using the EncoderFactory."""
+    dt = datatype.lower()
+    if dt in ("int", "int32", "integer32"):
+        return ef.createHLAinteger32BE(int(value)).toByteArray()
+    if dt in ("int64", "integer64"):
+        return ef.createHLAinteger64BE(int(value)).toByteArray()
+    if dt in ("float", "float64", "double"):
+        return ef.createHLAfloat64BE(float(value)).toByteArray()
+    if dt in ("string", "unicode"):
+        return ef.createHLAunicodeString(str(value)).toByteArray()
+    raise ValueError(f"unsupported FOM datatype {datatype!r}")
+
+
+def _decode_field(ef, datatype: str, raw):
+    """Decode one HLA byte[] back to a Python value."""
+    dt = datatype.lower()
+    if dt in ("int", "int32", "integer32"):
+        d = ef.createHLAinteger32BE(); d.decode(raw); return int(d.getValue())
+    if dt in ("int64", "integer64"):
+        d = ef.createHLAinteger64BE(); d.decode(raw); return int(d.getValue())
+    if dt in ("float", "float64", "double"):
+        d = ef.createHLAfloat64BE(); d.decode(raw); return float(d.getValue())
+    if dt in ("string", "unicode"):
+        d = ef.createHLAunicodeString(); d.decode(raw); return str(d.getValue())
+    raise ValueError(f"unsupported FOM datatype {datatype!r}")
+
+
+# ------------------------------------------------------------- the transport
+
+
+class PitchTransport(RTIConnector):
+    """RTIConnector backed by Pitch pRTI (IEEE 1516-2010) through JPype."""
+
+    capabilities = RTICapabilities(
+        name="pitch",
+        time_management=True,
+        timestamp_ordered=True,
+        interactions=True,
+        object_attributes=True,
+        default_lookahead=1.0,
+    )
+
+    def __init__(self, federation: str, federate: str, fom: str,
+                 fom_map: dict, *, federate_type: str = "pyjevsim",
+                 jvm_path: "str | None" = None, classpath=None,
+                 lookahead: float = 1.0, codec=None) -> None:
+        super().__init__(codec)
+        self._federation = federation
+        self._federate = federate
+        self._federate_type = federate_type
+        self._fom = fom
+        self._fom_map = dict(fom_map)
+        self._jvm_path = jvm_path
+        self._classpath = list(classpath or [])
+        self._lookahead = float(lookahead)
+
+        # Java handles, resolved after connect/join.
+        self._jpype = None
+        self._rtiamb = None
+        self._ef = None                 # EncoderFactory
+        self._time_factory = None
+        self._granted = threading.Event()
+        self._granted_time = 0.0
+        self._logical_time = 0.0        # last granted logical time
+        self._reg_enabled = threading.Event()
+        self._con_enabled = threading.Event()
+
+        # FOM resolution caches.
+        self._ic_handles: dict[str, Any] = {}          # fom_id -> InteractionClassHandle
+        self._param_handles: dict[str, dict] = {}      # fom_id -> {field: ParameterHandle}
+        self._oc_handles: dict[str, Any] = {}          # fom_id -> ObjectClassHandle
+        self._attr_handles: dict[str, dict] = {}       # fom_id -> {field: AttributeHandle}
+        self._obj_instances: dict[str, Any] = {}       # fom_id -> ObjectInstanceHandle (ours)
+        self._discovered: dict = {}                    # ObjectInstanceHandle -> fom_id (peers)
+        self._inbound_oc: dict = {}                    # ObjectClassHandle -> fom_id
+
+        self._boot_jvm()
+
+    # ----------------------------------------------------------- JVM / connect
+
+    def _boot_jvm(self) -> None:
+        import jpype  # lazy: only needed when the backend is actually used
+        self._jpype = jpype
+        if not jpype.isJVMStarted():
+            if self._jvm_path:
+                jpype.startJVM(self._jvm_path, classpath=self._classpath)
+            else:
+                jpype.startJVM(classpath=self._classpath)
+
+        RtiFactoryFactory = jpype.JClass("hla.rti1516e.RtiFactoryFactory")
+        factory = RtiFactoryFactory.getRtiFactory()
+        self._rtiamb = factory.getRtiAmbassador()
+        self._ef = factory.getEncoderFactory()
+        self._fed_amb = self._build_federate_ambassador()
+
+        CallbackModel = jpype.JClass("hla.rti1516e.CallbackModel")
+        # HLA_IMMEDIATE delivers callbacks on RTI-owned threads; our _emit ->
+        # insert_external_event is lock-protected, so that is safe.
+        self._rtiamb.connect(self._fed_amb, CallbackModel.HLA_IMMEDIATE)
+
+    def _build_federate_ambassador(self):
+        # JPype cannot subclass a concrete Java class (NullFederateAmbassador),
+        # so we implement the FederateAmbassador *interface* with a JProxy.
+        # Only the callbacks we care about are defined; __getattr__ supplies a
+        # no-op for every other interface method the RTI may invoke. Method
+        # name (not signature) selects the handler, so a single `*rest`
+        # definition covers all overloads of an callback.
+        jpype = self._jpype
+        outer = self
+
+        class _AmbImpl:
+            def timeRegulationEnabled(self, theTime):
+                outer._reg_enabled.set()
+
+            def timeConstrainedEnabled(self, theTime):
+                outer._con_enabled.set()
+
+            def timeAdvanceGrant(self, theTime):
+                outer._granted_time = float(theTime.getValue())
+                outer._granted.set()
+
+            def receiveInteraction(self, interactionClass, parameters, tag,
+                                   *rest):
+                outer._on_interaction(interactionClass, parameters, rest)
+
+            def discoverObjectInstance(self, theObject, theObjectClass,
+                                       objectName, *rest):
+                fom_id = outer._inbound_oc.get(theObjectClass)
+                if fom_id is not None:
+                    outer._discovered[theObject] = fom_id
+
+            def reflectAttributeValues(self, theObject, attributes, tag,
+                                       *rest):
+                outer._on_reflect(theObject, attributes, rest)
+
+            def __getattr__(self, name):
+                if name.startswith("__"):
+                    raise AttributeError(name)
+                return lambda *a, **k: None
+
+        # Keep a strong reference so the proxy target is not garbage-collected.
+        self._amb_impl = _AmbImpl()
+        return jpype.JProxy("hla.rti1516e.FederateAmbassador",
+                            inst=self._amb_impl)
+
+    # ------------------------------------------------------------- lifecycle
+
+    def _do_join(self, federation: str, federate_name: str, fom_paths) -> None:
+        jpype = self._jpype
+        File = jpype.JClass("java.io.File")
+        modules = [File(p).toURI().toURL() for p in (fom_paths or [self._fom])]
+        URLArr = jpype.JArray(jpype.JClass("java.net.URL"))
+        AlreadyExists = jpype.JClass(
+            "hla.rti1516e.exceptions.FederationExecutionAlreadyExists"
+        )
+        try:
+            self._rtiamb.createFederationExecution(federation, URLArr(modules))
+        except AlreadyExists:
+            pass  # another federate created it first — fine
+        # Any other exception (bad FOM, parse error, ...) propagates.
+
+        self._rtiamb.joinFederationExecution(
+            federate_name, self._federate_type, federation, URLArr(modules)
+        )
+
+        # Time management: regulating + constrained with our lookahead.
+        self._time_factory = self._rtiamb.getTimeFactory()
+        interval = self._time_factory.makeInterval(self._lookahead)
+        self._rtiamb.enableTimeRegulation(interval)
+        self._reg_enabled.wait(timeout=10)
+        self._rtiamb.enableTimeConstrained()
+        self._con_enabled.wait(timeout=10)
+
+    def _do_publish(self, binding) -> None:
+        spec = self._fom_map[binding.fom_id]
+        if spec["kind"] == "interaction":
+            h = self._interaction_handle(binding.fom_id, spec)
+            self._rtiamb.publishInteractionClass(h)
+        else:
+            oc, attrs = self._object_handles(binding.fom_id, spec)
+            self._rtiamb.publishObjectClassAttributes(oc, attrs)
+            # Register our instance up front so updates have a target.
+            self._obj_instances[binding.fom_id] = \
+                self._rtiamb.registerObjectInstance(oc)
+
+    def _do_subscribe(self, binding) -> None:
+        spec = self._fom_map[binding.fom_id]
+        if spec["kind"] == "interaction":
+            h = self._interaction_handle(binding.fom_id, spec)
+            self._rtiamb.subscribeInteractionClass(h)
+        else:
+            oc, attrs = self._object_handles(binding.fom_id, spec)
+            self._inbound_oc[oc] = binding.fom_id
+            self._rtiamb.subscribeObjectClassAttributes(oc, attrs)
+
+    def _do_resign(self) -> None:
+        jpype = self._jpype
+        OAD = jpype.JClass("hla.rti1516e.ResignAction")
+        try:
+            self._rtiamb.resignFederationExecution(OAD.DELETE_OBJECTS_THEN_DIVEST)
+        except jpype.JException:
+            pass
+        try:
+            self._rtiamb.destroyFederationExecution(self._federation)
+        except jpype.JException:
+            pass  # other federates still joined — fine
+
+    def _do_close(self) -> None:
+        if self._rtiamb is not None:
+            try:
+                self._rtiamb.disconnect()
+            except Exception:
+                pass
+        # We deliberately do NOT shutdown the JVM: other transports in the
+        # same process may still need it, and JPype cannot restart a JVM.
+
+    # ----------------------------------------------------------- data plane
+
+    def _do_send(self, binding, wire: Any, timestamp: "float | None") -> None:
+        spec = self._fom_map[binding.fom_id]
+        # wire is the pyjevsim payload (list); ping-pong inserts one dict.
+        record = wire[0] if isinstance(wire, (list, tuple)) and wire else wire
+        # TSO send time: the model's output() runs inside step(granted), so the
+        # earliest legal timestamp is the current logical time + lookahead.
+        send_t = timestamp if timestamp is not None else \
+            self._logical_time + self._lookahead
+        if spec["kind"] == "interaction":
+            self._send_interaction(binding.fom_id, spec, record, send_t)
+        else:
+            self._update_attributes(binding.fom_id, spec, record, send_t)
+
+    def _send_interaction(self, fom_id, spec, record, send_t) -> None:
+        h = self._interaction_handle(fom_id, spec)
+        params = self._rtiamb.getParameterHandleValueMapFactory().create(
+            len(spec["fields"])
+        )
+        ph = self._param_handles[fom_id]
+        for field, dtype in spec["fields"].items():
+            params.put(ph[field], _encode_field(self._ef, dtype, record[field]))
+        tag = self._jpype.JArray(self._jpype.JByte)(0)
+        self._rtiamb.sendInteraction(
+            h, params, tag, self._time_factory.makeTime(float(send_t))
+        )
+
+    def _update_attributes(self, fom_id, spec, record, send_t) -> None:
+        oc, _attrs = self._object_handles(fom_id, spec)
+        obj = self._obj_instances[fom_id]
+        amap = self._rtiamb.getAttributeHandleValueMapFactory().create(
+            len(spec["fields"])
+        )
+        ah = self._attr_handles[fom_id]
+        for field, dtype in spec["fields"].items():
+            amap.put(ah[field], _encode_field(self._ef, dtype, record[field]))
+        tag = self._jpype.JArray(self._jpype.JByte)(0)
+        self._rtiamb.updateAttributeValues(
+            obj, amap, tag, self._time_factory.makeTime(float(send_t))
+        )
+
+    # --------------------------------------------------------- inbound (RTI)
+
+    def _on_interaction(self, interactionClass, parameters, rest) -> None:
+        fom_id = self._ic_by_handle(interactionClass)
+        if fom_id is None:
+            return
+        spec = self._fom_map[fom_id]
+        ph = self._param_handles[fom_id]
+        record = {
+            field: _decode_field(self._ef, dtype, parameters.get(ph[field]))
+            for field, dtype in spec["fields"].items()
+        }
+        self._emit("interaction", fom_id, [record], _extract_time(rest))
+
+    def _on_reflect(self, theObject, attributes, rest) -> None:
+        fom_id = self._discovered.get(theObject)
+        if fom_id is None:
+            return
+        spec = self._fom_map[fom_id]
+        ah = self._attr_handles[fom_id]
+        record = {
+            field: _decode_field(self._ef, dtype, attributes.get(ah[field]))
+            for field, dtype in spec["fields"].items()
+            if attributes.containsKey(ah[field])
+        }
+        self._emit("attribute", fom_id, [record], _extract_time(rest))
+
+    # ------------------------------------------------------- time advance
+
+    def _do_request_time_advance(self, target: float) -> float:
+        self._granted.clear()
+        self._rtiamb.timeAdvanceRequest(self._time_factory.makeTime(float(target)))
+        self._granted.wait()
+        self._logical_time = self._granted_time
+        return self._granted_time
+
+    # --------------------------------------------------------- FOM handles
+
+    def _interaction_handle(self, fom_id, spec):
+        h = self._ic_handles.get(fom_id)
+        if h is None:
+            h = self._rtiamb.getInteractionClassHandle(spec["class"])
+            self._ic_handles[fom_id] = h
+            self._param_handles[fom_id] = {
+                field: self._rtiamb.getParameterHandle(h, field)
+                for field in spec["fields"]
+            }
+        return h
+
+    def _object_handles(self, fom_id, spec):
+        oc = self._oc_handles.get(fom_id)
+        if oc is None:
+            oc = self._rtiamb.getObjectClassHandle(spec["class"])
+            self._oc_handles[fom_id] = oc
+            ahs = self._rtiamb.getAttributeHandleSetFactory().create()
+            handles = {}
+            for field in spec["fields"]:
+                a = self._rtiamb.getAttributeHandle(oc, field)
+                handles[field] = a
+                ahs.add(a)
+            self._attr_handles[fom_id] = handles
+            self._attr_set_cache = getattr(self, "_attr_set_cache", {})
+            self._attr_set_cache[fom_id] = ahs
+        return oc, self._attr_set_cache[fom_id]
+
+    def _ic_by_handle(self, handle):
+        for fom_id, h in self._ic_handles.items():
+            if h.equals(handle):
+                return fom_id
+        return None
+
+
+def _extract_time(rest):
+    """Pull a LogicalTime value out of the trailing callback args, if any."""
+    for a in rest:
+        getv = getattr(a, "getValue", None)
+        if callable(getv):
+            try:
+                return float(getv())
+            except Exception:
+                continue
+    return None
+
+
+register_rti("pitch", lambda **kw: PitchTransport(**kw))

--- a/pyjevsim/hla/registry.py
+++ b/pyjevsim/hla/registry.py
@@ -1,0 +1,81 @@
+"""RTI backend registry — select an RTI by name.
+
+Lets applications choose an RTI without importing the backend class:
+
+    from pyjevsim.hla import create_rti, available_rtis
+
+    transport = create_rti("loopback")
+    # transport = create_rti("pitch", fom="Chat.xml", host="localhost")
+
+Third-party / optional backends register themselves at import time:
+
+    from pyjevsim.hla import register_rti
+    register_rti("pitch", lambda **kw: PitchTransport(**kw))
+
+Backends are kept out of the core import path so that an optional
+dependency (e.g. JPype for Pitch, a ZMQ surrogate, ...) is only required
+when that backend is actually requested.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Dict
+
+from .transport import LoopbackTransport, RTIConnector
+
+#: name -> factory(**kwargs) -> RTIConnector
+_BACKENDS: Dict[str, Callable[..., RTIConnector]] = {}
+
+
+def register_rti(name: str, factory: Callable[..., RTIConnector],
+                 *, replace: bool = False) -> None:
+    """Register an RTI backend factory under ``name``.
+
+    Args:
+        name: lookup key used by :func:`create_rti` (case-insensitive).
+        factory: callable returning an :class:`RTIConnector` (or any object
+            satisfying the ``Transport`` structural type). Called with the
+            keyword arguments passed to :func:`create_rti`.
+        replace: allow overwriting an existing registration. Defaults to
+            False so accidental name clashes fail loudly.
+    """
+    key = name.lower()
+    if key in _BACKENDS and not replace:
+        raise ValueError(
+            f"RTI backend {name!r} already registered "
+            f"(pass replace=True to override)"
+        )
+    _BACKENDS[key] = factory
+
+
+def unregister_rti(name: str) -> None:
+    """Remove a backend registration if present (no error if absent)."""
+    _BACKENDS.pop(name.lower(), None)
+
+
+def available_rtis() -> list[str]:
+    """Sorted list of registered backend names."""
+    return sorted(_BACKENDS)
+
+
+def create_rti(name: str, **kwargs):
+    """Instantiate the named RTI backend.
+
+    Raises:
+        KeyError: if ``name`` is not registered. The message lists the
+            backends that are available.
+    """
+    key = name.lower()
+    try:
+        factory = _BACKENDS[key]
+    except KeyError:
+        raise KeyError(
+            f"unknown RTI backend {name!r}; "
+            f"available: {available_rtis() or '[none registered]'}"
+        ) from None
+    return factory(**kwargs)
+
+
+# Built-in backend(s). Optional backends register from their own modules so
+# their dependencies stay lazy.
+register_rti("loopback", lambda **kw: LoopbackTransport(**kw))

--- a/pyjevsim/hla/transport.py
+++ b/pyjevsim/hla/transport.py
@@ -1,48 +1,274 @@
-"""Transport contract + LoopbackTransport + _HLARouter.
+"""RTI-agnostic transport interface + LoopbackTransport + _HLARouter.
 
-Spec: docs/hla/specification.md §2.
+Spec: docs/hla/specification.md §2 (data/time/lifecycle contract).
+Interface design: docs/hla/rti_interface.md (how to add a new RTI backend).
+
+Layering
+--------
+``Transport``        — minimal *structural* type (Protocol). Anything with
+                       ``send / on_receive / request_time_advance / close``
+                       satisfies it. Kept for back-compat and duck-typed
+                       test stubs.
+``RTIConnector``     — the *nominal* base class new backends should extend.
+                       It implements all the common plumbing (codec hook,
+                       single-callback dispatch, join/resign state machine,
+                       idempotent close) as template methods and leaves only
+                       the RTI-specific operations (``_do_*``) abstract. A
+                       new RTI (CERTI, Portico, OpenRTI, MAK, Pitch, ...)
+                       becomes ~5 small methods.
+``RTICapabilities``  — feature flags a backend advertises so callers can
+                       adapt (TSO? object attributes? time management?).
+``Codec``            — pluggable FOM (de)serialization, orthogonal to the
+                       wire transport. The same RTI can carry different
+                       FOMs; the same FOM codec can be reused across RTIs.
 """
 
 from __future__ import annotations
 
-from typing import Any, Callable, Protocol
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Callable, Protocol, runtime_checkable
 
+# callback(kind, fom_id, payload, timestamp)
 OnReceive = Callable[[str, str, Any, "float | None"], None]
 
 
+# --------------------------------------------------------------- capabilities
+
+
+@dataclass(frozen=True)
+class RTICapabilities:
+    """What an RTI backend can do.
+
+    Callers (and HLAExecutor / Federate) may consult these to adapt or to
+    fail fast — e.g. warn when timestamps are supplied but the backend
+    cannot deliver time-stamp-ordered (TSO), or when an ``HLAAttribute``
+    binding is used against an interactions-only transport.
+    """
+
+    name: str = "unknown"
+    time_management: bool = False        # regulating/constrained TAR/NER
+    timestamp_ordered: bool = False      # TSO delivery vs receive-order (RO)
+    interactions: bool = True            # sendInteraction / receiveInteraction
+    object_attributes: bool = False      # update/reflect attribute values
+    ddm: bool = False                    # data distribution management
+    ownership: bool = False              # ownership management
+    default_lookahead: "float | None" = None
+
+
+# --------------------------------------------------------------------- codec
+
+
+@runtime_checkable
+class Codec(Protocol):
+    """FOM (de)serialization, decoupled from the transport.
+
+    ``encode`` turns the pyjevsim-side ``payload`` (always the list returned
+    by ``SysMessage.retrieve()``) into whatever the backend ships on the
+    wire. ``decode`` is the inverse for inbound events. The default
+    :class:`IdentityCodec` passes objects through unchanged (loopback /
+    in-process backends); real RTIs supply a codec that maps to the FOM
+    datatypes (e.g. HLA 1516e ``HLAfixedRecord`` via the EncoderFactory).
+    """
+
+    def encode(self, binding, payload: Any) -> Any: ...
+    def decode(self, kind: str, fom_id: str, wire: Any) -> Any: ...
+
+
+class IdentityCodec:
+    """Pass-through codec. Used by in-process backends (loopback)."""
+
+    def encode(self, binding, payload: Any) -> Any:
+        return payload
+
+    def decode(self, kind: str, fom_id: str, wire: Any) -> Any:
+        return wire
+
+
+# ----------------------------------------------------------- structural type
+
+
 class Transport(Protocol):
+    """Minimal structural transport contract (spec §2.1).
+
+    Retained for back-compat and for duck-typed test stubs. New backends
+    should subclass :class:`RTIConnector` instead, which guarantees the
+    full lifecycle surface (join/publish/subscribe/resign) that
+    :class:`~pyjevsim.hla.federate.Federate` delegates to.
+    """
+
     def send(self, binding, payload: Any) -> None: ...
     def on_receive(self, callback: OnReceive) -> None: ...
     def request_time_advance(self, target: float) -> float: ...
     def close(self) -> None: ...
 
 
-class LoopbackTransport:
-    """In-process transport: mirrors out→in to a single registered callback.
+# ----------------------------------------------------------- nominal base
 
-    Test-only. send on direction="in" is a no-op (loopback only mirrors
-    out→in). request_time_advance is identity. close is idempotent.
+
+class RTIConnector(ABC):
+    """Base class for RTI backends — the recommended extension point.
+
+    Implements the common mechanics so a concrete backend only has to
+    provide the RTI-specific ``_do_*`` operations:
+
+    Required (abstract):
+        * ``_do_send(binding, wire, timestamp)``
+        * ``_do_request_time_advance(target) -> granted``
+
+    Optional (default no-op — override if the RTI needs them):
+        * ``_do_join(federation, federate_name, fom_paths)``
+        * ``_do_publish(binding)`` / ``_do_subscribe(binding)``
+        * ``_do_resign()`` / ``_do_close()``
+
+    Inbound path: the backend's receive thread calls :meth:`_emit` with
+    the raw wire object; the connector decodes it and forwards to the
+    single registered callback (the ``_HLARouter``). ``_emit`` may be
+    invoked from any thread — the downstream
+    ``SysExecutor.insert_external_event`` is lock-protected.
     """
 
-    def __init__(self) -> None:
-        self._cb: OnReceive | None = None
+    #: Backends override with their own capability set.
+    capabilities: RTICapabilities = RTICapabilities()
 
-    def send(self, binding, payload: Any) -> None:
-        # §2.2: only mirror out and inout (the outbound side).
+    def __init__(self, codec: "Codec | None" = None) -> None:
+        self._codec: Codec = codec or IdentityCodec()
+        self._callback: "OnReceive | None" = None
+        self._joined = False
+        self._closed = False
+
+    # ------------------------------------------------------------ data plane
+
+    def send(self, binding, payload: Any, *, timestamp: "float | None" = None) -> None:
+        """Publish an outbound binding's payload to the RTI.
+
+        Direction is enforced here: only ``out``/``inout`` bindings are
+        shipped (an ``in`` binding handed to ``send`` is dropped, matching
+        spec §2.2). ``payload`` is always the list from
+        ``SysMessage.retrieve()``. ``timestamp`` carries the logical send
+        time for TSO-capable backends (``None`` => receive-order).
+        """
         if binding.direction not in ("out", "inout"):
             return
-        if self._cb is None:
-            return
-        self._cb(binding.kind, binding.fom_id, payload, None)
+        wire = self._codec.encode(binding, payload)
+        self._do_send(binding, wire, timestamp)
 
     def on_receive(self, callback: OnReceive) -> None:
-        self._cb = callback
+        """Register the single inbound subscriber (re-registering replaces)."""
+        self._callback = callback
+
+    def _emit(self, kind: str, fom_id: str, wire: Any,
+              timestamp: "float | None" = None) -> None:
+        """Backend RX hook: decode wire and dispatch to the callback."""
+        cb = self._callback
+        if cb is None:
+            return
+        payload = self._codec.decode(kind, fom_id, wire)
+        cb(kind, fom_id, payload, timestamp)
+
+    # ------------------------------------------------------------ time plane
 
     def request_time_advance(self, target: float) -> float:
-        return target
+        """Block until the RTI grants; return the granted logical time."""
+        return self._do_request_time_advance(target)
+
+    # ------------------------------------------------------------- lifecycle
+
+    def join(self, federation: str, federate_name: str, fom_paths) -> None:
+        if self._joined:
+            raise RuntimeError("join() called twice")
+        self._do_join(federation, federate_name, fom_paths)
+        self._joined = True
+
+    def publish(self, binding) -> None:
+        self._require_joined("publish")
+        self._do_publish(binding)
+
+    def subscribe(self, binding) -> None:
+        self._require_joined("subscribe")
+        self._do_subscribe(binding)
+
+    def resign(self) -> None:
+        if not self._joined:
+            return
+        self._do_resign()
+        self._joined = False
 
     def close(self) -> None:
-        self._cb = None
+        if self._closed:
+            return
+        if self._joined:
+            try:
+                self.resign()
+            except Exception:
+                pass
+        self._do_close()
+        self._closed = True
+
+    @property
+    def joined(self) -> bool:
+        return self._joined
+
+    def _require_joined(self, op: str) -> None:
+        if not self._joined:
+            raise RuntimeError(f"{op}() called before join()")
+
+    # ----------------------------------------------------- RTI-specific hooks
+
+    @abstractmethod
+    def _do_send(self, binding, wire: Any, timestamp: "float | None") -> None:
+        """Ship an encoded outbound binding to the RTI."""
+
+    @abstractmethod
+    def _do_request_time_advance(self, target: float) -> float:
+        """Issue a time-advance request; return the granted logical time."""
+
+    # Optional lifecycle hooks — default no-ops so trivial backends
+    # (loopback, in-process) need not implement them.
+    def _do_join(self, federation: str, federate_name: str, fom_paths) -> None:
+        pass
+
+    def _do_publish(self, binding) -> None:
+        pass
+
+    def _do_subscribe(self, binding) -> None:
+        pass
+
+    def _do_resign(self) -> None:
+        pass
+
+    def _do_close(self) -> None:
+        pass
+
+
+# ------------------------------------------------------------- loopback impl
+
+
+class LoopbackTransport(RTIConnector):
+    """In-process transport: mirrors out→in to the registered callback.
+
+    Test / demo backend. ``send`` on an ``out``/``inout`` binding is
+    delivered straight back through ``_emit`` (the router then fans it out
+    to subscribed executors). ``request_time_advance`` is identity (no flow
+    control). Lifecycle methods are inherited no-ops.
+    """
+
+    capabilities = RTICapabilities(
+        name="loopback",
+        time_management=False,
+        timestamp_ordered=False,
+        interactions=True,
+        object_attributes=True,
+    )
+
+    def _do_send(self, binding, wire: Any, timestamp: "float | None") -> None:
+        self._emit(binding.kind, binding.fom_id, wire, timestamp)
+
+    def _do_request_time_advance(self, target: float) -> float:
+        return target
+
+
+# ------------------------------------------------------------------ router
 
 
 class _HLARouter:
@@ -52,7 +278,7 @@ class _HLARouter:
     the same (kind, fom_id); all receive each event.
     """
 
-    def __init__(self, transport: Transport) -> None:
+    def __init__(self, transport) -> None:
         self._transport = transport
         self._subs: dict[tuple[str, str], list] = {}
         transport.on_receive(self._dispatch)
@@ -73,6 +299,6 @@ class _HLARouter:
             del self._subs[key]
 
     def _dispatch(self, kind: str, fom_id: str, payload: Any,
-                  timestamp: float | None) -> None:
+                  timestamp: "float | None") -> None:
         for ex in tuple(self._subs.get((kind, fom_id), ())):
             ex._on_rti_event(kind, fom_id, payload, timestamp)

--- a/pyjevsim/system_executor.py
+++ b/pyjevsim/system_executor.py
@@ -361,10 +361,20 @@ class SysExecutor(CoreModel):
         self.port_map = {}
 
     def single_output_handling(self, obj, msg):
-        """
-        Handles a single output message.
+        """Immediate (non-two-phase) delivery of a single message.
 
-        Used by the HLA ``step()`` path and ``handle_external_input_event``.
+        .. deprecated::
+            **Legacy path — no longer on the main simulation tick.** Both
+            :py:meth:`schedule` (V_TIME / R_TIME) and :py:meth:`step`
+            (HLA_TIME) now route every event through the shared two-phase
+            body :py:meth:`_run_instant`, which delivers correct
+            ``con_trans`` / output-before-transition semantics. This
+            method dispatches ``ext_trans`` immediately and cannot
+            produce ``con_trans``; it is retained only for backward
+            compatibility with external callers and by the legacy
+            :py:meth:`handle_external_input_event`. Prefer
+            ``insert_external_event`` + the normal tick.
+
         Each delivered message triggers ``ext_trans`` + ``set_req_time``
         on the receiver and an immediate re-push into the priority queue
         so the receiver's new request_time takes effect (ScheduleQueue
@@ -382,7 +392,7 @@ class SysExecutor(CoreModel):
         for destination in self._destinations_for(obj, msg.get_dst()):
             if destination[0] is self:
                 with self.condition:
-                    self.output_event_queue.append((self.global_time, msg[1].retrieve()))
+                    self.output_event_queue.append((self.global_time, msg.retrieve()))
                 if self._output_event_callback:
                     self._output_event_callback()
             elif destination[0].get_obj_id() in self.active_obj_map:
@@ -475,50 +485,139 @@ class SysExecutor(CoreModel):
             return fallback
         return self._NO_DESTINATIONS
 
+    def _run_instant(self, instant, imminent):
+        """Execute one Parallel-DEVS two-phase tick at simulated time
+        ``instant``.
+
+        This is the **single shared tick body** used by both execution
+        paths — :py:meth:`schedule` (V_TIME / R_TIME) and :py:meth:`step`
+        (HLA_TIME) — so all three modes deliver identical DEVS semantics.
+
+        Previously the V_TIME / R_TIME path processed external events in a
+        separate pre-pass (``handle_external_input_event`` ->
+        ``single_output_handling``) that ran ``ext_trans`` *before*
+        imminent models computed ``output()``, and could never produce
+        ``con_trans``. That diverged from the HLA ``step`` path (which
+        folds externals into the tick) and violated DEVS — ``output()``
+        must observe pre-transition state, and a model that is both
+        imminent and externally influenced at one instant must receive
+        ``con_trans``. Folding external events into this shared body fixes
+        both discrepancies.
+
+        Phases:
+          * A — collect ``output()`` from every imminent (pre-transition).
+          * B — route outputs through coupling into a per-receiver bag,
+            already seeded with external events due at ``<= instant``.
+          * C — dispatch the correct transition per affected model:
+            imminent + receiving -> ``con_trans``; imminent only ->
+            ``int_trans``; receiving only -> ``ext_trans``.
+          * D — bulk reschedule every affected model.
+
+        Args:
+            instant (float): simulated time of this tick. ``global_time``
+                must already equal ``instant``.
+            imminent (list): executors already popped for ``instant``.
+                May be empty when only external events are due.
+        """
+        active_obj_map = self.active_obj_map
+        callback = self._output_event_callback
+        output_queue = self.output_event_queue
+
+        # Seed the per-receiver bag with external events due at <= instant.
+        # An external event whose destination model is imminent this
+        # instant lands in the same bag, so Phase C dispatches con_trans
+        # rather than a separate ext_trans (TSO / confluent delivery).
+        influenced_inputs = {}      # dst_executor -> list[(dst_port, msg)]
+        if self.input_event_queue:
+            with self.condition:
+                while (self.input_event_queue
+                       and self.input_event_queue[0][0] <= instant):
+                    _, ext_msg = heapq.heappop(self.input_event_queue)
+                    for dst_exec, dst_port in self._destinations_for(
+                        self, ext_msg.get_dst()
+                    ):
+                        if dst_exec is not self and dst_exec._obj_id in active_obj_map:
+                            influenced_inputs.setdefault(
+                                dst_exec, []
+                            ).append((dst_port, ext_msg))
+
+        if not imminent and not influenced_inputs:
+            return
+
+        # Phase A — collect lambda outputs from imminents.
+        outputs = []
+        for X in imminent:
+            md = MessageDeliverer()
+            X.output(md)
+            if md.has_contents():
+                outputs.append((X, md))
+
+        # Phase B — route outputs through coupling, merging into the bag
+        # already seeded with external events.
+        for X, md in outputs:
+            for msg in md.get_contents():
+                for dst_exec, dst_port in self._destinations_for(X, msg.get_dst()):
+                    if dst_exec is self:
+                        # External output of the whole simulator. When no
+                        # callback is registered we are in the
+                        # single-thread fast path and the lock is
+                        # unnecessary.
+                        if callback is not None:
+                            with self.condition:
+                                output_queue.append((instant, msg))
+                            callback()
+                        else:
+                            output_queue.append((instant, msg))
+                    elif dst_exec._obj_id in active_obj_map:
+                        influenced_inputs.setdefault(
+                            dst_exec, []
+                        ).append((dst_port, msg))
+
+        imminent_set = set(imminent)
+        affected = imminent_set | set(influenced_inputs)
+
+        # Phase C — apply the right transition for every affected model.
+        for M in affected:
+            bag = influenced_inputs.get(M, ())
+            is_imminent = M in imminent_set
+            if is_imminent and bag:
+                M.con_trans(bag)
+            elif is_imminent:
+                M.int_trans()
+            else:
+                for port, msg in bag:
+                    M.ext_trans(port, msg)
+
+        # Phase D — bulk reschedule via ScheduleQueue.push. Each push
+        # snapshots the new req_time and supersedes the prior entry (lazy
+        # invalidation). No heapify; tuple comparison settles ordering.
+        for M in affected:
+            M.set_req_time(instant)
+            self.min_schedule_item.push(M)
+
     def schedule(self):
-        """Run one simulated-instant tick using Parallel-DEVS two-phase
-        scheduling.
+        """Run one simulated-instant tick (V_TIME / R_TIME).
 
-        Phase A — pop every imminent executor (those whose ``req_time``
-        has been reached) and invoke ``output()`` on each.
+        The tick body — Phases A–D, including external-event integration
+        and Parallel-DEVS ``con_trans`` semantics — is shared with the
+        HLA :py:meth:`step` path via :py:meth:`_run_instant`, so V_TIME,
+        R_TIME, and HLA_TIME deliver identical DEVS behaviour.
+        ``schedule`` adds only the time-advance rule (Phase E):
 
-        Phase B — route the collected outputs through the coupling map
-        and assemble per-receiver bags of incoming messages.
-
-        Phase C — for every model that is imminent and/or influenced,
-        invoke the correct DEVS transition:
-
-            * imminent + receiving  -> ``con_trans(bag)``  (confluent)
-            * imminent only         -> ``int_trans()``
-            * receiving only        -> ``ext_trans(port, msg)`` per msg
-
-        Phase D — bulk-reschedule every affected model with one
-        ``set_req_time(global_time)`` and ``heappush`` per model. No
-        ``heapify`` runs; lazy reschedule is fine because DEVS always
-        moves req_times forward in time.
-
-        Time advancement rules (Phase E):
           * V_TIME: jump ``global_time`` to ``min(next_event, target_time)``.
             If more events are still due at the current instant the
             timestamp is left unchanged so the next ``schedule()`` call
             processes them in another round at the same simulated time.
           * R_TIME: step by ``time_resolution`` and sleep to match
             wall-clock pace.
-          * HLA_TIME: do not advance ``global_time`` here; the RTI sets
-            it via ``step(granted_time)``.
         """
         self.create_entity()
-        self.handle_external_input_event()
 
         # `time.perf_counter()` is only consulted at the bottom of this
         # method to compute the R_TIME sleep delta. Avoid the syscall
-        # in V_TIME / HLA_TIME where the value is never read.
+        # in V_TIME where the value is never read.
         is_realtime = self.ex_mode == ExecutionType.R_TIME
         before = time.perf_counter() if is_realtime else None
-
-        active_obj_map = self.active_obj_map
-        callback = self._output_event_callback
-        output_queue = self.output_event_queue
 
         # Phase A — pop all imminents at the current global_time.
         # The heapset's `pop_all_at(t)` drains a whole bucket in one O(1)
@@ -534,58 +633,9 @@ class SysExecutor(CoreModel):
                 break
             imminent.extend(fel.pop_all_at(next_t))
 
-        if imminent:
-            # Phase A continued — collect lambda outputs.
-            outputs = []
-            for X in imminent:
-                md = MessageDeliverer()
-                X.output(md)
-                if md.has_contents():
-                    outputs.append((X, md))
-
-            # Phase B — route outputs through coupling, build per-receiver bag.
-            influenced_inputs = {}      # dst_executor -> list[(dst_port, msg)]
-            current_time = self.global_time
-            for X, md in outputs:
-                for msg in md.get_contents():
-                    for dst_exec, dst_port in self._destinations_for(X, msg.get_dst()):
-                        if dst_exec is self:
-                            # External output: when no callback is
-                            # registered we are in the single-thread
-                            # fast path and the lock is unnecessary.
-                            if callback is not None:
-                                with self.condition:
-                                    output_queue.append((current_time, msg))
-                                callback()
-                            else:
-                                output_queue.append((current_time, msg))
-                        elif dst_exec._obj_id in active_obj_map:
-                            influenced_inputs.setdefault(
-                                dst_exec, []
-                            ).append((dst_port, msg))
-
-            imminent_set = set(imminent)
-            affected = imminent_set | set(influenced_inputs)
-
-            # Phase C — apply the right transition for every affected model.
-            for M in affected:
-                bag = influenced_inputs.get(M, ())
-                is_imminent = M in imminent_set
-                if is_imminent and bag:
-                    M.con_trans(bag)
-                elif is_imminent:
-                    M.int_trans()
-                else:
-                    for port, msg in bag:
-                        M.ext_trans(port, msg)
-
-            # Phase D — bulk reschedule via ScheduleQueue.push. Each
-            # push snapshots the new req_time and supersedes the prior
-            # entry (lazy invalidation). No heapify; no `__lt__` on
-            # executor objects — tuple comparison settles ordering.
-            for M in affected:
-                M.set_req_time(current_time)
-                fel.push(M)
+        # Phases A(output)–D, with external events folded into the same
+        # instant so imminent + externally-influenced models get con_trans.
+        self._run_instant(self.global_time, imminent)
 
         # Phase E — advance simulated time.
         # CPython attribute writes are atomic at the bytecode level, so
@@ -709,11 +759,11 @@ class SysExecutor(CoreModel):
         # `next_t > granted_time` — any event scheduled past the grant
         # stays in the FEL for a future `step()`.
         #
-        # External events from `input_event_queue` participate in the
-        # same round as imminents at the same instant: they are drained
-        # into `influenced_inputs` alongside imminents' lambda outputs
-        # so Phase C can dispatch `con_trans` correctly when a model is
-        # both imminent and externally influenced (TSO delivery).
+        # The per-instant tick body is shared with the V_TIME / R_TIME
+        # `schedule` path via `_run_instant`, which also drains external
+        # events at <= next_t into the same round so a model that is both
+        # imminent and externally influenced gets `con_trans` (TSO
+        # delivery).
         while self.min_schedule_item or self.input_event_queue:
             next_internal = self.min_schedule_item.peek_time(default=Infinite)
             next_external = (self.input_event_queue[0][0]
@@ -724,72 +774,12 @@ class SysExecutor(CoreModel):
             if next_t > self.global_time:
                 self.global_time = next_t
 
-            # Drain externals at <= next_t and seed influenced_inputs
-            # with their (dst_port, msg) pairs.
-            influenced_inputs = {}
-            with self.condition:
-                while (self.input_event_queue
-                       and self.input_event_queue[0][0] <= next_t):
-                    _, ext_msg = heapq.heappop(self.input_event_queue)
-                    for dst_exec, dst_port in self._destinations_for(
-                        self, ext_msg.get_dst()
-                    ):
-                        if dst_exec.get_obj_id() in self.active_obj_map:
-                            influenced_inputs.setdefault(
-                                dst_exec, []
-                            ).append((dst_port, ext_msg))
-
-            # Phase A — pop every imminent at this instant.
+            # Phase A — pop every imminent at this instant; `_run_instant`
+            # folds in externals due at <= next_t. When the peek returned
+            # a stale entry (no imminent, no external) `_run_instant` is a
+            # no-op and the loop re-peeks, pruning the stale time.
             imminent = self.min_schedule_item.pop_all_at(next_t)
-            if not imminent and not influenced_inputs:
-                # The peek returned a stale entry (already removed or
-                # just pruned); loop again.
-                continue
-
-            # Phase A continued — collect lambda outputs from imminents.
-            outputs = []
-            for X in imminent:
-                md = MessageDeliverer()
-                X.output(md)
-                if md.has_contents():
-                    outputs.append((X, md))
-
-            # Phase B — route outputs through coupling, merge into
-            # influenced_inputs (already seeded with externals).
-            for X, md in outputs:
-                for msg in md.get_contents():
-                    for dst_exec, dst_port in self._destinations_for(X, msg.get_dst()):
-                        if dst_exec is self:
-                            with self.condition:
-                                self.output_event_queue.append(
-                                    (self.global_time, msg)
-                                )
-                            if self._output_event_callback:
-                                self._output_event_callback()
-                        elif dst_exec.get_obj_id() in self.active_obj_map:
-                            influenced_inputs.setdefault(
-                                dst_exec, []
-                            ).append((dst_port, msg))
-
-            imminent_set = set(imminent)
-            affected = imminent_set | set(influenced_inputs)
-
-            # Phase C — apply the right transition for every affected model.
-            for M in affected:
-                bag = influenced_inputs.get(M, ())
-                is_imminent = M in imminent_set
-                if is_imminent and bag:
-                    M.con_trans(bag)
-                elif is_imminent:
-                    M.int_trans()
-                else:
-                    for port, msg in bag:
-                        M.ext_trans(port, msg)
-
-            # Phase D — bulk reschedule.
-            for M in affected:
-                M.set_req_time(self.global_time)
-                self.min_schedule_item.push(M)
+            self._run_instant(next_t, imminent)
 
         # IEEE 1516-2010 convention: after a successful grant the
         # federate's logical time equals the granted time, even if the
@@ -892,7 +882,19 @@ class SysExecutor(CoreModel):
             return deque(self.output_event_queue)
 
     def handle_external_input_event(self):
-        """Handles external input events.
+        """Drain due external events and deliver them immediately.
+
+        .. deprecated::
+            **Legacy path — no longer called by the main tick.**
+            :py:meth:`schedule` and :py:meth:`step` now fold external
+            events into the shared two-phase body :py:meth:`_run_instant`,
+            which gives correct ``con_trans`` semantics (a model that is
+            both imminent and externally influenced at one instant fires
+            ``con_trans``, not ``ext_trans`` then a separate
+            ``int_trans``) and guarantees ``output()`` is computed before
+            any transition at the instant. This method delivers via the
+            immediate :py:meth:`single_output_handling` path and is kept
+            only for backward compatibility with external callers.
 
         Fast-path: if the queue is empty there is nothing to do, and we
         can skip both the lock acquisition and the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,9 @@ dependencies = ["dill>=0.3.6"]
 
 [project.optional-dependencies]
 dev = ["pytest>=7.0"]
+# HLA Pitch pRTI backend (in-process JVM bridge). JPype>=1.6 needs Java>=9;
+# pin jpype1<=1.5 for Java 8. Not needed for the loopback/inprocess backends.
+hla-pitch = ["jpype1>=1.5"]
 
 [project.urls]
 Homepage = "https://github.com/eventsim/pyjevsim"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyjevsim"
-version = "2.0.1"
+version = "2.1.0"
 description = "A DEVS(Discrete Event System Specification) Modeling & Simulation environment with journaling functionality"
 readme = "README.md"
 license = "MIT"

--- a/tests/hla/test_pingpong.py
+++ b/tests/hla/test_pingpong.py
@@ -1,0 +1,161 @@
+"""Ping-pong over two federates — RTI-agnostic logic verification.
+
+Runs the *example* models (examples/hla_pingpong) as two separate
+SysExecutor federates joined to one in-process federation, covering the four
+deliverables without needing Java / pRTI:
+
+  1. federates named ping / pong
+  2. federation join / resign
+  3. interaction send (the rally, both directions)
+  4. object attribute synchronization (Ping.hits reflected by Pong)
+
+The same models run against real Pitch pRTI via the ``pitch`` backend
+(see tests/hla/test_pitch_backend.py, skipped when the toolchain is absent).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+# Import the example models (the authoritative ping-pong implementation).
+_EXAMPLE_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "examples", "hla_pingpong")
+)
+sys.path.insert(0, _EXAMPLE_DIR)
+from pingpong_models import (  # noqa: E402
+    Ping,
+    Pong,
+    ping_bindings,
+    pong_bindings,
+)
+
+from pyjevsim import ExecutionType, SysExecutor  # noqa: E402
+from pyjevsim.hla import (  # noqa: E402
+    Federate,
+    HLAExecutorFactory,
+    InProcessFederation,
+    InProcessRTI,
+)
+
+
+def _build(model, bindings, model_name, federation):
+    se = SysExecutor(_time_resolution=1, ex_mode=ExecutionType.HLA_TIME)
+    tx = InProcessRTI(federation=federation)
+    se.exec_factory = HLAExecutorFactory(tx, {model_name: bindings})
+    se.register_entity(model)
+    se.init_sim()
+    return se, tx, Federate(se, tx)
+
+
+@pytest.fixture
+def pingpong():
+    """A joined ping + pong pair on a shared federation, pre-run 8 rounds."""
+    federation = InProcessFederation("PingPong")
+    ping_se, ping_tx, ping_fed = _build(Ping("ping", max_volleys=3),
+                                        ping_bindings(), "ping", federation)
+    pong_se, pong_tx, pong_fed = _build(Pong("pong"),
+                                        pong_bindings(), "pong", federation)
+    return {
+        "federation": federation,
+        "ping_se": ping_se, "ping_tx": ping_tx, "ping_fed": ping_fed,
+        "pong_se": pong_se, "pong_tx": pong_tx, "pong_fed": pong_fed,
+    }
+
+
+def _join_all(ctx):
+    for fed, name, binds in (
+        (ctx["ping_fed"], "ping", ping_bindings()),
+        (ctx["pong_fed"], "pong", pong_bindings()),
+    ):
+        fed.join("PingPong", name, fom_paths=["PingPong.xml"])
+        for b in binds.values():
+            if b.direction in ("out", "inout"):
+                fed.publish(b)
+            if b.direction in ("in", "inout"):
+                fed.subscribe(b)
+
+
+def _run(ctx, rounds=8):
+    for t in range(1, rounds + 1):
+        ctx["ping_se"].step(t)
+        ctx["pong_se"].step(t)
+
+
+# ----------------------------------------------------- 2. join / resign
+
+
+def test_join_attaches_both_federates(pingpong):
+    assert len(pingpong["federation"].members) == 0
+    _join_all(pingpong)
+    assert pingpong["ping_tx"].joined and pingpong["pong_tx"].joined
+    assert len(pingpong["federation"].members) == 2
+
+
+def test_publish_before_join_raises(pingpong):
+    from pyjevsim.hla import HLAInteraction
+    with pytest.raises(RuntimeError):
+        pingpong["ping_fed"].publish(HLAInteraction("PingPong.Ping", direction="out"))
+
+
+def test_resign_detaches_both_federates(pingpong):
+    _join_all(pingpong)
+    pingpong["ping_fed"].resign()
+    pingpong["pong_fed"].resign()
+    assert not pingpong["ping_tx"].joined and not pingpong["pong_tx"].joined
+    assert len(pingpong["federation"].members) == 0
+
+
+# ----------------------------------------------------- 3. interaction send
+
+
+def test_interaction_rally_both_directions(pingpong):
+    _join_all(pingpong)
+    _run(pingpong, rounds=8)
+
+    ping = pingpong["ping_se"].get_entity("ping")[0].get_core_model()
+    pong = pingpong["pong_se"].get_entity("pong")[0].get_core_model()
+
+    # Ping served (0) then returned 1,2,3 → Pong saw 0..3; Pong returned
+    # each → Ping saw 0..3. Exactly max_volleys+1 balls each way.
+    assert [d["count"] for d in pong.received_pings] == [0, 1, 2, 3]
+    assert [d["count"] for d in ping.received_pongs] == [0, 1, 2, 3]
+    # sender field carried across the interaction.
+    assert all(d["sender"] == "ping" for d in pong.received_pings)
+    assert all(d["sender"] == "pong" for d in ping.received_pongs)
+
+
+# ----------------------------------------------------- 4. object sync
+
+
+def test_object_attribute_synchronization(pingpong):
+    _join_all(pingpong)
+    _run(pingpong, rounds=8)
+
+    ping = pingpong["ping_se"].get_entity("ping")[0].get_core_model()
+    pong = pingpong["pong_se"].get_entity("pong")[0].get_core_model()
+
+    # Pong reflected the hits attribute Ping published on every volley.
+    assert pong.reflected_hits == [0, 1, 2, 3]
+    # The reflected values track Ping's own ball counter.
+    assert pong.reflected_hits[-1] == ping.count - 1 or pong.reflected_hits[-1] == ping.count
+
+
+# ----------------------------------------------------- isolation
+
+
+def test_separate_federations_do_not_cross_talk():
+    """Two federations on separate buses must not exchange events."""
+    fed_a = InProcessFederation("A")
+    fed_b = InProcessFederation("B")
+    a_se, a_tx, a_fed = _build(Ping("ping", max_volleys=3), ping_bindings(), "ping", fed_a)
+    b_se, b_tx, b_fed = _build(Pong("pong"), pong_bindings(), "pong", fed_b)
+    a_fed.join("A", "ping", fom_paths=["x"])
+    b_fed.join("B", "pong", fom_paths=["x"])
+    for t in range(1, 6):
+        a_se.step(t)
+        b_se.step(t)
+    pong = b_se.get_entity("pong")[0].get_core_model()
+    assert pong.received_pings == [], "different federations must be isolated"

--- a/tests/hla/test_pitch_backend.py
+++ b/tests/hla/test_pitch_backend.py
@@ -1,0 +1,152 @@
+"""Pitch pRTI backend tests — guarded; skip when the toolchain is absent.
+
+These exercise the *real* PitchTransport against a live Pitch pRTI. They are
+skipped automatically unless the full stack is available:
+
+  * JPype importable AND able to start a JVM (needs Java >= 9 for JPype>=1.6);
+  * ``prti1516e.jar`` discoverable (PRTI_HOME env var or the default install);
+  * for the live-federation cases, the env var ``PYJEVSIM_PITCH_LIVE=1`` and a
+    running CRC.
+
+Verified live against **Pitch pRTI Free 5.5.2** with **Temurin 11** via::
+
+    set PYJEVSIM_JVM=C:\\Program Files\\Eclipse Adoptium\\jdk-11...\\bin\\server\\jvm.dll
+    set PYJEVSIM_PITCH_LIVE=1            # with a running CRC
+    pytest tests/hla/test_pitch_backend.py
+
+Without ``PYJEVSIM_JVM`` the default suite stays hermetic (these cases skip);
+the protocol-level ping-pong behaviour is also covered deterministically by
+tests/hla/test_pingpong.py against the in-process bus. The PitchTransport
+remains importable regardless (its JPype import is lazy).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+PRTI_HOME = os.environ.get("PRTI_HOME", r"C:\Program Files\prti1516e")
+JAR = os.path.join(PRTI_HOME, "lib", "prti1516e.jar")
+FOM = os.path.abspath(os.path.join(
+    os.path.dirname(__file__), "..", "..",
+    "examples", "hla_pingpong", "fom", "PingPong.xml"))
+
+sys.path.insert(0, os.path.abspath(os.path.join(
+    os.path.dirname(__file__), "..", "..", "examples", "hla_pingpong")))
+
+
+JVM = os.environ.get("PYJEVSIM_JVM")  # explicit Java>=9 jvm.dll (optional)
+
+
+def _jvm_bootable() -> bool:
+    try:
+        import jpype
+    except Exception:
+        return False
+    if not os.path.exists(JAR):
+        return False
+    try:
+        if not jpype.isJVMStarted():
+            if JVM:
+                jpype.startJVM(JVM, classpath=[JAR])
+            else:
+                jpype.startJVM(classpath=[JAR])
+        return True
+    except Exception:
+        return False
+
+
+jvm_ok = _jvm_bootable()
+live = os.environ.get("PYJEVSIM_PITCH_LIVE") == "1"
+
+requires_jvm = pytest.mark.skipif(
+    not jvm_ok,
+    reason="JPype + Java>=9 + prti1516e.jar required (set PRTI_HOME)",
+)
+requires_live = pytest.mark.skipif(
+    not (jvm_ok and live),
+    reason="set PYJEVSIM_PITCH_LIVE=1 with a running CRC for live federation",
+)
+
+
+def test_pitch_backend_is_registered():
+    """Always runs: the backend self-registers even without JPype."""
+    from pyjevsim.hla import available_rtis
+    assert "pitch" in available_rtis()
+
+
+def test_pitch_import_does_not_require_jpype():
+    """Importing the module must not pull in JPype (lazy dependency)."""
+    import importlib
+    mod = importlib.import_module("pyjevsim.hla.backends.pitch")
+    assert hasattr(mod, "PitchTransport")
+
+
+@requires_jvm
+def test_encoder_round_trip():
+    """The 1516e field codec round-trips int/string via the EncoderFactory."""
+    import jpype
+    from pyjevsim.hla.backends.pitch import _decode_field, _encode_field
+
+    factory = jpype.JClass("hla.rti1516e.RtiFactoryFactory").getRtiFactory()
+    ef = factory.getEncoderFactory()
+    assert _decode_field(ef, "int32", _encode_field(ef, "int32", 42)) == 42
+    assert _decode_field(ef, "string", _encode_field(ef, "string", "ping")) == "ping"
+
+
+@requires_live
+def test_live_pingpong_join_interaction_object():
+    """End-to-end against a real CRC: join, rally, object sync, resign.
+
+    Two time-managed federates run in their own threads (each is both
+    regulating and constrained); the RTI coordinates time-advance grants
+    and TSO delivery. Mirrors examples/hla_pingpong/run_pitch.py.
+    """
+    import threading
+
+    from pingpong_models import (
+        PINGPONG_FOM_MAP, Ping, Pong, ping_bindings, pong_bindings,
+    )
+
+    from pyjevsim import ExecutionType, SysExecutor
+    from pyjevsim.hla import Federate, HLAExecutorFactory, create_rti
+
+    def build(model, bindings, name):
+        se = SysExecutor(_time_resolution=1, ex_mode=ExecutionType.HLA_TIME)
+        tx = create_rti("pitch", federation="PingPong", federate=name,
+                        fom=FOM, fom_map=PINGPONG_FOM_MAP,
+                        jvm_path=JVM, classpath=[JAR], lookahead=1.0)
+        se.exec_factory = HLAExecutorFactory(tx, {name: bindings})
+        se.register_entity(model)
+        se.init_sim()
+        return se, Federate(se, tx)
+
+    ping_se, ping_fed = build(Ping("ping", max_volleys=3), ping_bindings(), "ping")
+    pong_se, pong_fed = build(Pong("pong"), pong_bindings(), "pong")
+    for fed, name, binds in ((ping_fed, "ping", ping_bindings()),
+                             (pong_fed, "pong", pong_bindings())):
+        fed.join("PingPong", name, fom_paths=[FOM])
+        for b in binds.values():
+            if b.direction in ("out", "inout"):
+                fed.publish(b)
+            if b.direction in ("in", "inout"):
+                fed.subscribe(b)
+
+    t_ping = threading.Thread(target=ping_fed.run_until, args=(25.0, 1.0))
+    t_pong = threading.Thread(target=pong_fed.run_until, args=(25.0, 1.0))
+    t_ping.start(); t_pong.start()
+    t_ping.join(); t_pong.join()
+
+    ping = ping_se.get_entity("ping")[0].get_core_model()
+    pong = pong_se.get_entity("pong")[0].get_core_model()
+
+    ping_counts = [d["count"] for d in pong.received_pings]   # 3. interaction
+    pong_counts = [d["count"] for d in ping.received_pongs]
+    assert ping_counts == list(range(len(ping_counts))) and len(ping_counts) >= 3
+    assert pong_counts == list(range(len(pong_counts))) and len(pong_counts) >= 3
+    assert pong.reflected_hits == ping_counts                 # 4. object sync
+
+    ping_fed.resign()                                          # 2. resign
+    pong_fed.resign()

--- a/tests/hla/test_rti_interface.py
+++ b/tests/hla/test_rti_interface.py
@@ -1,0 +1,211 @@
+"""RTI-agnostic interface: RTIConnector template, codec, registry.
+
+These tests pin the contract that lets *any* RTI plug into pyjevsim:
+
+  * A backend only implements ``_do_send`` + ``_do_request_time_advance``
+    (and optional lifecycle hooks); the base class supplies direction
+    enforcement, codec (de)serialization, single-callback dispatch, the
+    join/resign state machine, and idempotent close.
+  * Codecs are invoked on the send/receive boundary and are orthogonal to
+    the transport.
+  * The registry selects a backend by name without importing its class.
+  * A custom backend works end-to-end through HLAExecutorFactory +
+    Federate exactly like LoopbackTransport.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pyjevsim import ExecutionType, SysExecutor
+from pyjevsim.hla import (
+    Federate,
+    HLAExecutorFactory,
+    HLAInteraction,
+    IdentityCodec,
+    RTICapabilities,
+    RTIConnector,
+    available_rtis,
+    create_rti,
+    register_rti,
+    unregister_rti,
+)
+
+from .conftest import EmitOnce
+
+
+# --------------------------------------------------------- a minimal backend
+
+
+class _MiniRTI(RTIConnector):
+    """Smallest possible backend: in-memory mirror + recorded lifecycle.
+
+    Demonstrates that a new RTI needs only the two abstract hooks; the
+    lifecycle/codec/dispatch plumbing comes from RTIConnector.
+    """
+
+    capabilities = RTICapabilities(
+        name="mini", time_management=True, timestamp_ordered=True,
+        interactions=True, object_attributes=True, default_lookahead=1.0,
+    )
+
+    def __init__(self, codec=None):
+        super().__init__(codec)
+        self.sent = []
+        self.lifecycle = []
+
+    def _do_send(self, binding, wire, timestamp):
+        self.sent.append((binding.fom_id, wire, timestamp))
+        # Mirror out→in so subscribers see it (like loopback).
+        self._emit(binding.kind, binding.fom_id, wire, timestamp)
+
+    def _do_request_time_advance(self, target):
+        return target
+
+    def _do_join(self, federation, federate_name, fom_paths):
+        self.lifecycle.append(("join", federation, federate_name))
+
+    def _do_publish(self, binding):
+        self.lifecycle.append(("publish", binding.fom_id))
+
+    def _do_subscribe(self, binding):
+        self.lifecycle.append(("subscribe", binding.fom_id))
+
+    def _do_resign(self):
+        self.lifecycle.append(("resign",))
+
+    def _do_close(self):
+        self.lifecycle.append(("close",))
+
+
+# --------------------------------------------------------------- base class
+
+
+class TestRTIConnectorTemplate:
+    def test_direction_guard_blocks_inbound_send(self):
+        rti = _MiniRTI()
+        rti.send(HLAInteraction("X", direction="in"), [{"a": 1}])
+        assert rti.sent == [], "an 'in' binding handed to send must be dropped"
+
+    def test_send_emits_to_callback(self):
+        rti = _MiniRTI()
+        seen = []
+        rti.on_receive(lambda *a: seen.append(a))
+        rti.send(HLAInteraction("Comm.Chat", direction="out"), [{"t": "hi"}], timestamp=4.0)
+        assert rti.sent == [("Comm.Chat", [{"t": "hi"}], 4.0)]
+        assert seen == [("interaction", "Comm.Chat", [{"t": "hi"}], 4.0)]
+
+    def test_publish_before_join_raises(self):
+        rti = _MiniRTI()
+        with pytest.raises(RuntimeError):
+            rti.publish(HLAInteraction("X", direction="out"))
+        with pytest.raises(RuntimeError):
+            rti.subscribe(HLAInteraction("X", direction="in"))
+
+    def test_join_twice_raises(self):
+        rti = _MiniRTI()
+        rti.join("Fed", "a", [])
+        with pytest.raises(RuntimeError):
+            rti.join("Fed", "a", [])
+
+    def test_lifecycle_state_machine(self):
+        rti = _MiniRTI()
+        assert rti.joined is False
+        rti.join("Fed", "a", ["f.xml"])
+        assert rti.joined is True
+        rti.publish(HLAInteraction("X", direction="out"))
+        rti.subscribe(HLAInteraction("Y", direction="in"))
+        rti.resign()
+        assert rti.joined is False
+        assert rti.lifecycle == [
+            ("join", "Fed", "a"),
+            ("publish", "X"),
+            ("subscribe", "Y"),
+            ("resign",),
+        ]
+
+    def test_close_is_idempotent_and_auto_resigns(self):
+        rti = _MiniRTI()
+        rti.join("Fed", "a", [])
+        rti.close()
+        rti.close()  # second call must be a no-op
+        assert rti.lifecycle.count(("resign",)) == 1
+        assert rti.lifecycle.count(("close",)) == 1
+
+
+# ------------------------------------------------------------------- codec
+
+
+class TestCodec:
+    def test_custom_codec_round_trips(self):
+        class _UpperCodec(IdentityCodec):
+            def encode(self, binding, payload):
+                return [str(p).upper() for p in payload]
+
+            def decode(self, kind, fom_id, wire):
+                return wire  # already encoded by the mirror
+
+        rti = _MiniRTI(codec=_UpperCodec())
+        seen = []
+        rti.on_receive(lambda *a: seen.append(a))
+        rti.send(HLAInteraction("X", direction="out"), ["hi", "yo"])
+        # encode ran on the way out; mirror carried the encoded wire back.
+        assert rti.sent[0][1] == ["HI", "YO"]
+        assert seen[0][2] == ["HI", "YO"]
+
+
+# ---------------------------------------------------------------- registry
+
+
+class TestRegistry:
+    def test_loopback_is_registered_by_default(self):
+        assert "loopback" in available_rtis()
+        t = create_rti("loopback")
+        assert isinstance(t, RTIConnector)
+
+    def test_register_and_create_custom(self):
+        register_rti("mini-test", lambda **kw: _MiniRTI(**kw), replace=True)
+        try:
+            assert "mini-test" in available_rtis()
+            t = create_rti("mini-test")
+            assert isinstance(t, _MiniRTI)
+            assert t.capabilities.name == "mini"
+        finally:
+            unregister_rti("mini-test")
+
+    def test_duplicate_registration_rejected(self):
+        register_rti("dup", lambda **kw: _MiniRTI(**kw), replace=True)
+        try:
+            with pytest.raises(ValueError):
+                register_rti("dup", lambda **kw: _MiniRTI(**kw))
+        finally:
+            unregister_rti("dup")
+
+    def test_unknown_backend_raises_with_listing(self):
+        with pytest.raises(KeyError):
+            create_rti("no-such-rti")
+
+
+# -------------------------------------------------------------- end-to-end
+
+
+def test_custom_backend_works_through_federate():
+    """A custom RTIConnector drives a full federate exactly like loopback:
+    output on a bound port reaches the RTI and mirrors back to a
+    subscribed model via the normal HLAExecutor/router/insert path."""
+    rti = _MiniRTI()
+    sys_exec = SysExecutor(_time_resolution=1, ex_mode=ExecutionType.HLA_TIME)
+
+    bindings = {"out": HLAInteraction("Comm.Ping", direction="out")}
+    sys_exec.exec_factory = HLAExecutorFactory(rti, {"emitter": bindings})
+    sys_exec.register_entity(EmitOnce("emitter", payload={"ping": 1}))
+
+    fed = Federate(sys_exec, rti)
+    fed.join("Fed", "emitter", fom_paths=["f.xml"])
+    fed.publish(bindings["out"])
+    fed.run_until(end_time=3.0, lookahead=1.0)
+    fed.resign()
+
+    assert rti.sent, "the bound output must have been shipped to the RTI"
+    assert rti.sent[0][0] == "Comm.Ping"
+    assert ("join", "Fed", "emitter") in rti.lifecycle

--- a/tests/test_confluent.py
+++ b/tests/test_confluent.py
@@ -167,6 +167,74 @@ def test_subclass_can_override_con_trans():
     assert order == ["ext", "int"]
 
 
+def test_confluent_on_external_event_path_v_time():
+    """A model that is imminent at instant *t* and also receives an
+    **external** event (``insert_external_event``) at *t* must fire
+    ``con_trans`` — not a separate ``ext_trans`` then ``int_trans``.
+
+    This pins the fix for the legacy V_TIME path: external events used to
+    be delivered by ``handle_external_input_event`` ->
+    ``single_output_handling`` *before* the two-phase tick, which ran
+    ``ext_trans`` ahead of imminent ``output()`` and could never produce
+    ``con_trans``. Both ``schedule`` (V_TIME/R_TIME) and ``step``
+    (HLA_TIME) now share ``_run_instant`` so the external and internal
+    event paths are semantically identical.
+    """
+
+    class _TimedAtomic(BehaviorModel):
+        """Imminent at t=DEADLINE; counts each transition kind."""
+
+        def __init__(self, name, deadline):
+            super().__init__(name)
+            self.insert_state("active", deadline)
+            self.insert_state("done")
+            self.init_state("active")
+            self.insert_input_port("in")
+            self.insert_output_port("out")
+            self.n_int = 0
+            self.n_ext = 0
+            self.n_con = 0
+
+        def ext_trans(self, port, msg):
+            self.n_ext += 1
+
+        def int_trans(self):
+            self.n_int += 1
+            self._cur_state = "done"
+
+        def con_trans(self, port_msgs):
+            self.n_con += 1
+            self._cur_state = "done"
+
+        def output(self, md):
+            if self._cur_state == "active":
+                m = SysMessage(self.get_name(), "out")
+                m.insert(1)
+                md.insert_message(m)
+
+    ss = SysExecutor(1, ex_mode=ExecutionType.V_TIME, snapshot_manager=None)
+    a = _TimedAtomic("A", deadline=2.0)
+    ss.register_entity(a)
+    ss.insert_input_port("ext_in")
+    ss.coupling_relation(None, "ext_in", a, "in")
+
+    # A is imminent at t=2 (its deadline). Time an external event for the
+    # same instant so A is simultaneously imminent and receiving.
+    ss.insert_external_event("ext_in", None, scheduled_time=2)
+
+    ss.simulate(5, _tm=False)
+
+    assert a.n_con == 1, (
+        f"A should fire con_trans exactly once (imminent + external event "
+        f"coincide at t=2); counts int={a.n_int}, ext={a.n_ext}, "
+        f"con={a.n_con}"
+    )
+    assert a.n_ext == 0 and a.n_int == 0, (
+        f"the coincident event must NOT split into separate ext/int; "
+        f"int={a.n_int}, ext={a.n_ext}"
+    )
+
+
 def test_no_confluent_when_only_imminent():
     """A model with no input bag must fire `int_trans`, never `con_trans`."""
     log = []


### PR DESCRIPTION
## Summary

Release **2.1.0**. Adds a pluggable HLA RTI backend layer (so any RTI can drive a pyjevsim federate), a live **Pitch pRTI** (IEEE 1516-2010) backend, a two-federate ping-pong example, and unifies the core DEVS tick across all three execution modes.

## Changes

**Core — unified tick (`85173b5`)**
- `SysExecutor.schedule` (V_TIME/R_TIME) and `SysExecutor.step` (HLA_TIME) now share one two-phase tick body, `_run_instant`.
- Fixes external-event semantics on the V_TIME/R_TIME path: events used to be delivered by a legacy pre-pass that ran `ext_trans` before imminent models' `output()` and could never produce `con_trans`. They now flow through the shared tick — a model that is both imminent and externally influenced at one instant correctly fires `con_trans` (TSO/confluent). Legacy methods kept (deprecated); latent `msg[1]` bug fixed.

**HLA RTI backend layer (`9d9c69a`)**
- `RTIConnector` template-method base — a backend implements only `_do_send` + `_do_request_time_advance` (+ optional lifecycle hooks); direction enforcement, FOM codec, single-callback dispatch, join/resign state machine and idempotent close are inherited.
- `RTICapabilities` (feature negotiation), `Codec`/`IdentityCodec`, and a name→factory registry (`register_rti`/`create_rti`/`available_rtis`).
- Backends: `InProcessRTI` (multi-federate in-process bus, no Java) and `PitchTransport` (Pitch pRTI via JPype).
- Example `examples/hla_pingpong/` (ping/pong federates), `hla-pitch` optional extra, docs in `docs/hla/rti_interface.md`.

**Release + docs (`3bdb93f`, `3056908`)**
- Version 2.0.1 → 2.1.0 (`pyproject.toml`, `docs/source/conf.py`), CHANGELOG `[2.1.0]`.
- README + Sphinx updated; new `docs/source/pyjevsim_hla.rst`.

## Testing

- `pytest tests/`: **110 passed, 2 skipped** (hermetic; Pitch live/encoder skip without a JVM).
- Pitch backend **verified live** against Pitch pRTI Free 5.5.2 with Temurin 11: join/resign, interaction rally both directions, object-attribute sync — `pong received pings: [0,1,2,3]`, `ping received pongs: [0,1,2,3]`, `pong reflected hits: [0,1,2,3]`. Guarded test passes with `PYJEVSIM_JVM` + `PYJEVSIM_PITCH_LIVE` + a running CRC.
- `python -m build` + `twine check`: PASSED (sdist/wheel); clean-venv install verified `version 2.1.0`, backends `['inprocess','loopback','pitch']`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)