### PR TITLE
fix(hla): ping-pong models match per-item inbound injection (fixes 2 failing tests on main)

### DIFF
--- a/examples/hla_pingpong/pingpong_models.py
+++ b/examples/hla_pingpong/pingpong_models.py
@@ -45,9 +45,9 @@ class Ping(BehaviorModel):
 
     def ext_trans(self, port, msg):
         if port == "in_pong":
-            # Inbound contract: retrieve()[0] is the peer's full
-            # retrieve() list; our payload is its single dict.
-            data = msg.retrieve()[0][0]
+            # HLAExecutor injects each item of the peer's retrieve() list
+            # as one external event, so retrieve()[0] is our single dict.
+            data = msg.retrieve()[0]
             self.received_pongs.append(data)
             self.count = int(data["count"]) + 1
             self._cur_state = "rally" if self.count <= self.max_volleys else "idle"
@@ -84,12 +84,12 @@ class Pong(BehaviorModel):
 
     def ext_trans(self, port, msg):
         if port == "in_ping":
-            data = msg.retrieve()[0][0]
+            data = msg.retrieve()[0]
             self.received_pings.append(data)
             self.count = int(data["count"])
             self._cur_state = "return"
         elif port == "in_hits":
-            data = msg.retrieve()[0][0]
+            data = msg.retrieve()[0]
             self.reflected_hits.append(int(data["hits"]))
 
     def int_trans(self):


### PR DESCRIPTION
## Problem

After #15 (2.1.0) was **squash-merged** onto a `main` that had independently
updated `HLAExecutor`, two tests fail on `main`:

- `tests/hla/test_pingpong.py::test_interaction_rally_both_directions`
- `tests/hla/test_pingpong.py::test_object_attribute_synchronization`

`KeyError` at `examples/hla_pingpong/pingpong_models.py`.

## Root cause

`main`'s `HLAExecutor._on_rti_event` injects **each item** of the sender's
`retrieve()` list as a separate external event:

```python
for item in payload:
    self.parent.insert_external_event(sys_port, item, scheduled_time=delay)
```

so a receiver sees `retrieve()[0] == {payload dict}`. The ping-pong models
(authored against the older whole-list injection on the 2.1.0 branch) used
`retrieve()[0][0]`, i.e. `{dict}[0]` → `KeyError`. The squash brought the
models but kept main's improved `HLAExecutor`, so the two diverged.

## Fix

Use `retrieve()[0]` in `Ping`/`Pong` `ext_trans` (3 sites).

## Verification (on main + this fix)

- `pytest tests/`: **110 passed, 2 skipped**.
- `run_inprocess.py`: `pong received pings: [0,1,2,3]`,
  `ping received pongs: [0,1,2,3]`, `pong reflected hits: [0,1,2,3]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)