### PR TITLE
chore(release): 2.1.1 — republish from main (PyPI 2.1.0 shipped an older build)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.1] — 2026-06-28
+
+### Fixed
+- Republish from ``main``. The PyPI **2.1.0** artifact was built from the
+  feature branch before it was reconciled with ``main`` and shipped an
+  older ``HLAExecutor`` inbound convention (whole-list
+  ``insert_external_event``) that differed from the tagged ``main`` source
+  (per-item injection). PyPI versions are immutable, so 2.1.0 cannot be
+  replaced; 2.1.1 is the canonical build from ``main`` (the in-tree
+  behaviour and tests are unchanged from the 2.1.0 source on ``main``).
+
 ## [2.1.0] — 2026-06-28
 
 ### Added
@@ -167,7 +178,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `SysExecutor` with V_TIME and R_TIME execution modes, port-based
   coupling, and `dill`-backed serialization.
 
-[Unreleased]: https://github.com/eventsim/pyjevsim/compare/v2.1.0...HEAD
+[Unreleased]: https://github.com/eventsim/pyjevsim/compare/v2.1.1...HEAD
+[2.1.1]: https://github.com/eventsim/pyjevsim/compare/v2.1.0...v2.1.1
 [2.1.0]: https://github.com/eventsim/pyjevsim/compare/v2.0.1...v2.1.0
 [2.0.1]: https://github.com/eventsim/pyjevsim/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/eventsim/pyjevsim/compare/v1.3.1...v2.0.0

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,8 +12,8 @@ sys.path.insert(0, os.path.abspath('../..'))
 project = 'pyjevsim'
 author = 'Changbeom Choi'
 copyright = '2024-2026, Changbeom Choi'
-version = '2.1.0'
-release = '2.1.0'
+version = '2.1.1'
+release = '2.1.1'
 
 extensions = [
     'sphinx.ext.autodoc',      

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyjevsim"
-version = "2.1.0"
+version = "2.1.1"
 description = "A DEVS(Discrete Event System Specification) Modeling & Simulation environment with journaling functionality"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Why

The PyPI **2.1.0** artifact was uploaded from the feature-branch `dist/`
before it was reconciled with `main`, so its `pyjevsim/hla/hla_executor.py`
ships the **older inbound convention** (whole-list `insert_external_event`)
instead of the `main`/tagged source (per-item injection, from #16).

PyPI versions are immutable — 2.1.0 cannot be overwritten or its filename
reused. **2.1.1** is the canonical build from `main`.

## Changes

- `pyproject.toml`, `docs/source/conf.py`: `2.1.0` → `2.1.1`
- `CHANGELOG.md`: `[2.1.1]` entry + compare link

No in-tree behaviour change versus the 2.1.0 source on `main`; this is a
packaging/republish bump.

## Verification

- `pytest tests/`: **110 passed, 2 skipped**.

## Follow-up (manual)

- After merge: tag `v2.1.1` on main, build from main, `twine upload`.
- Optionally **yank** PyPI 2.1.0 so installs resolve to 2.1.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)