### PR TITLE
feat(hla): multi-process distributed ping-pong demo + RTI sync points

### DIFF
--- a/examples/hla_pingpong/README.md
+++ b/examples/hla_pingpong/README.md
@@ -83,11 +83,30 @@ python examples/hla_pingpong/run_pitch_federate.py pong
 python examples/hla_pingpong/run_pitch_federate.py ping
 ```
 
-> Verified live (two processes, Pitch pRTI Free 5.5.2 + Temurin 11):
-> `pong received pings: [0, 1, 2, 3]`, `ping received pongs: [0, 1, 2, 3]`,
-> `pong reflected hits: [0, 1, 2, 3]`, both `resigned`, exit 0. The two
-> federates synchronize on a `ready` federation synchronization point
-> before exchanging any event.
+### Across two hosts
+
+The only thing that distinguishes a multi-host run is where the CRC lives.
+Run the CRC on one machine and point each federate at it with
+`PYJEVSIM_CRC=<crc-host>:8989` (the LRC then connects to the CRC over the
+network instead of localhost):
+
+```bash
+# host A (also runs the CRC) — responder
+set PYJEVSIM_CRC=192.168.1.10:8989
+python examples/hla_pingpong/run_pitch_federate.py pong
+# host B — server
+set PYJEVSIM_CRC=192.168.1.10:8989
+python examples/hla_pingpong/run_pitch_federate.py ping
+```
+
+> Verified live (two separate OS processes, Pitch pRTI Free 5.5.2 +
+> Temurin 11): `pong received pings: [0, 1, 2, 3]`,
+> `ping received pongs: [0, 1, 2, 3]`, `pong reflected hits: [0, 1, 2, 3]`,
+> both `resigned`, exit 0. The federates synchronize on a `ready`
+> federation synchronization point before exchanging any event. The same
+> run also succeeds with `PYJEVSIM_CRC` set to the host's routable LAN
+> address (not `localhost`), confirming the network transport path — a
+> second host on the LAN connects identically.
 
 Switching backend is the only change — the models and wiring are identical:
 

--- a/examples/hla_pingpong/README.md
+++ b/examples/hla_pingpong/README.md
@@ -19,7 +19,9 @@ Pitch pRTI. Only the transport (chosen via `create_rti(...)`) changes.
 | `pingpong_models.py` | `Ping` / `Pong` models + HLA bindings + Pitch FOM map |
 | `fom/PingPong.xml` | IEEE 1516-2010 FOM (interactions `Ping`/`Pong`, object `PingPaddle`) |
 | `run_inprocess.py` | Offline demo — two federates over `InProcessRTI` (no Java) |
-| `run_pitch.py` | Live demo — two federates over Pitch pRTI (`pitch` backend) |
+| `run_pitch.py` | Live demo — two federates (two threads) in one process over Pitch pRTI |
+| `run_pitch_federate.py` | **One federate per OS process** (`ping`/`pong` arg) — true distributed run |
+| `run_pitch_multiprocess.py` | Launcher that spawns both federate processes and streams their output |
 
 ## Run offline (no Java / RTI needed)
 
@@ -52,9 +54,40 @@ Prerequisites:
 3. `PRTI_HOME` set (default `C:\Program Files\prti1516e`). Optionally
    `PYJEVSIM_JVM` to point at a specific `jvm.dll` (use a Java ≥ 9 runtime).
 
+Single process (two federates as two threads):
+
 ```bash
 python examples/hla_pingpong/run_pitch.py
 ```
+
+### Distributed: one federate per process
+
+Each federate runs in its own OS process (own JVM and LRC), joined to the
+same federation through the CRC — a genuine distributed run. The federates
+may live on different hosts; point each at the CRC (e.g. `PYJEVSIM_CRC` /
+your pRTI client settings).
+
+One command (spawns both, starts `pong` then `ping`):
+
+```bash
+python examples/hla_pingpong/run_pitch_multiprocess.py
+```
+
+Or two terminals (start `pong` first so the start sync-point is announced
+to both federates):
+
+```bash
+# terminal 1
+python examples/hla_pingpong/run_pitch_federate.py pong
+# terminal 2
+python examples/hla_pingpong/run_pitch_federate.py ping
+```
+
+> Verified live (two processes, Pitch pRTI Free 5.5.2 + Temurin 11):
+> `pong received pings: [0, 1, 2, 3]`, `ping received pongs: [0, 1, 2, 3]`,
+> `pong reflected hits: [0, 1, 2, 3]`, both `resigned`, exit 0. The two
+> federates synchronize on a `ready` federation synchronization point
+> before exchanging any event.
 
 Switching backend is the only change — the models and wiring are identical:
 

--- a/examples/hla_pingpong/run_pitch_federate.py
+++ b/examples/hla_pingpong/run_pitch_federate.py
@@ -42,6 +42,7 @@ PRTI_HOME = os.environ.get("PRTI_HOME", r"C:\Program Files\prti1516e")
 JAR = os.path.join(PRTI_HOME, "lib", "prti1516e.jar")
 FOM = os.path.join(os.path.dirname(__file__), "fom", "PingPong.xml")
 JVM_PATH = os.environ.get("PYJEVSIM_JVM")          # Java >= 9 jvm.dll
+CRC = os.environ.get("PYJEVSIM_CRC")               # e.g. 192.168.1.10:8989
 SYNC = "ready"
 
 
@@ -57,7 +58,7 @@ def build_role(role: str, max_volleys: int):
         "pitch",
         federation="PingPong", federate=role,
         fom=FOM, fom_map=PINGPONG_FOM_MAP,
-        jvm_path=JVM_PATH, classpath=[JAR], lookahead=1.0,
+        jvm_path=JVM_PATH, classpath=[JAR], lookahead=1.0, crc=CRC,
     )
     se.exec_factory = HLAExecutorFactory(tx, {role: bindings})
     se.register_entity(model)

--- a/examples/hla_pingpong/run_pitch_federate.py
+++ b/examples/hla_pingpong/run_pitch_federate.py
@@ -1,0 +1,114 @@
+"""One ping-pong federate per OS process — a true multi-process HLA demo.
+
+Run each federate in its own process (own JVM, own LRC), joined to the same
+Pitch pRTI federation. The RTI mediates all data exchange and time
+management, so the two federates are genuinely distributed (and may be on
+different hosts — point each at the CRC with ``PYJEVSIM_CRC``).
+
+Two terminals:
+
+    # terminal 1
+    set PYJEVSIM_JVM=C:\\Program Files\\Eclipse Adoptium\\jdk-11...\\bin\\server\\jvm.dll
+    python examples/hla_pingpong/run_pitch_federate.py pong
+
+    # terminal 2 (start within a few seconds; a sync point makes order safe)
+    python examples/hla_pingpong/run_pitch_federate.py ping
+
+Both federates register/await a ``ready`` synchronization point before any
+data flows, so neither serves until both have joined and subscribed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+sys.path.insert(0, os.path.dirname(__file__))
+
+from pingpong_models import (  # noqa: E402
+    PINGPONG_FOM_MAP,
+    Ping,
+    Pong,
+    ping_bindings,
+    pong_bindings,
+)
+
+from pyjevsim import ExecutionType, SysExecutor  # noqa: E402
+from pyjevsim.hla import Federate, HLAExecutorFactory, create_rti  # noqa: E402
+
+PRTI_HOME = os.environ.get("PRTI_HOME", r"C:\Program Files\prti1516e")
+JAR = os.path.join(PRTI_HOME, "lib", "prti1516e.jar")
+FOM = os.path.join(os.path.dirname(__file__), "fom", "PingPong.xml")
+JVM_PATH = os.environ.get("PYJEVSIM_JVM")          # Java >= 9 jvm.dll
+SYNC = "ready"
+
+
+def build_role(role: str, max_volleys: int):
+    if role == "ping":
+        model, bindings = Ping("ping", max_volleys=max_volleys), ping_bindings()
+    elif role == "pong":
+        model, bindings = Pong("pong"), pong_bindings()
+    else:
+        raise SystemExit(f"role must be 'ping' or 'pong', got {role!r}")
+    se = SysExecutor(_time_resolution=1, ex_mode=ExecutionType.HLA_TIME)
+    tx = create_rti(
+        "pitch",
+        federation="PingPong", federate=role,
+        fom=FOM, fom_map=PINGPONG_FOM_MAP,
+        jvm_path=JVM_PATH, classpath=[JAR], lookahead=1.0,
+    )
+    se.exec_factory = HLAExecutorFactory(tx, {role: bindings})
+    se.register_entity(model)
+    se.init_sim()
+    return se, tx, Federate(se, tx), bindings
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("role", choices=["ping", "pong"])
+    ap.add_argument("--end-time", type=float, default=25.0)
+    ap.add_argument("--lookahead", type=float, default=1.0)
+    ap.add_argument("--max-volleys", type=int, default=3)
+    args = ap.parse_args()
+
+    se, tx, fed, bindings = build_role(args.role, args.max_volleys)
+
+    fed.join("PingPong", args.role, fom_paths=[FOM])
+    for b in bindings.values():
+        if b.direction in ("out", "inout"):
+            fed.publish(b)
+        if b.direction in ("in", "inout"):
+            fed.subscribe(b)
+    print(f"[{args.role}] joined + published/subscribed", flush=True)
+
+    # Start barrier: ping registers the sync point, both achieve it once
+    # announced, and both wait until the whole federation is synchronized
+    # before any event is exchanged. This removes the join/subscribe race.
+    # (Start pong before ping so the point is registered after both joined.)
+    if args.role == "ping":
+        tx.register_sync_point(SYNC)
+    if not tx.wait_sync_announced(SYNC):
+        raise SystemExit(f"[{args.role}] sync point '{SYNC}' not announced (timeout)")
+    tx.achieve_sync_point(SYNC)
+    if not tx.wait_synchronized(SYNC):
+        raise SystemExit(f"[{args.role}] federation not synchronized (timeout)")
+    print(f"[{args.role}] federation synchronized - starting", flush=True)
+
+    fed.run_until(end_time=args.end_time, lookahead=args.lookahead)
+
+    model = se.get_entity(args.role)[0].get_core_model()
+    if args.role == "pong":
+        print(f"[pong] received pings: {[d['count'] for d in model.received_pings]}", flush=True)
+        print(f"[pong] reflected hits: {model.reflected_hits}", flush=True)
+    else:
+        print(f"[ping] received pongs: {[d['count'] for d in model.received_pongs]}", flush=True)
+
+    fed.resign()
+    tx.close()
+    print(f"[{args.role}] resigned", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/hla_pingpong/run_pitch_multiprocess.py
+++ b/examples/hla_pingpong/run_pitch_multiprocess.py
@@ -1,0 +1,66 @@
+"""Launch the two-process Pitch ping-pong demo from one command.
+
+Spawns ``run_pitch_federate.py pong`` and ``run_pitch_federate.py ping`` as
+two separate OS processes (each with its own JVM/LRC) joined to the same
+live Pitch pRTI federation, and streams their output. Requires a running
+CRC and ``PYJEVSIM_JVM`` set to a Java >= 9 ``jvm.dll``.
+
+    python examples/hla_pingpong/run_pitch_multiprocess.py
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import threading
+
+HERE = os.path.dirname(__file__)
+FEDERATE = os.path.join(HERE, "run_pitch_federate.py")
+
+
+def _pump(proc, prefix):
+    for line in proc.stdout:
+        sys.stdout.write(f"{prefix} {line}")
+        sys.stdout.flush()
+
+
+def main() -> int:
+    env = dict(os.environ)
+
+    def spawn(role):
+        return subprocess.Popen(
+            [sys.executable, FEDERATE, role],
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            text=True, env=env,
+        )
+
+    # Start pong (the subscriber) first and wait until it has joined and
+    # subscribed before launching ping. ping then registers the start
+    # synchronization point with both federates already joined, so the
+    # RTI announces it to both (a point registered before a federate joins
+    # is not announced to that late joiner).
+    pong = spawn("pong")
+    for line in pong.stdout:
+        sys.stdout.write(f"pong| {line}")
+        sys.stdout.flush()
+        if "joined + published/subscribed" in line:
+            break
+
+    ping = spawn("ping")
+    threads = [
+        threading.Thread(target=_pump, args=(pong, "pong|")),
+        threading.Thread(target=_pump, args=(ping, "ping|")),
+    ]
+    for t in threads:
+        t.start()
+    pong.wait(); ping.wait()
+    for t in threads:
+        t.join()
+
+    print(f"\nexit codes: pong={pong.returncode} ping={ping.returncode}")
+    return pong.returncode or ping.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyjevsim/hla/backends/pitch.py
+++ b/pyjevsim/hla/backends/pitch.py
@@ -100,7 +100,8 @@ class PitchTransport(RTIConnector):
     def __init__(self, federation: str, federate: str, fom: str,
                  fom_map: dict, *, federate_type: str = "pyjevsim",
                  jvm_path: "str | None" = None, classpath=None,
-                 lookahead: float = 1.0, codec=None) -> None:
+                 lookahead: float = 1.0, crc: "str | None" = None,
+                 codec=None) -> None:
         super().__init__(codec)
         self._federation = federation
         self._federate = federate
@@ -110,6 +111,10 @@ class PitchTransport(RTIConnector):
         self._jvm_path = jvm_path
         self._classpath = list(classpath or [])
         self._lookahead = float(lookahead)
+        # CRC endpoint ("host" or "host:port"); None => the RTI default
+        # (localhost). Pointing this at another host is all that turns a
+        # local federation into a multi-host one.
+        self._crc = crc
 
         # Java handles, resolved after connect/join.
         self._jpype = None
@@ -159,7 +164,15 @@ class PitchTransport(RTIConnector):
         CallbackModel = jpype.JClass("hla.rti1516e.CallbackModel")
         # HLA_IMMEDIATE delivers callbacks on RTI-owned threads; our _emit ->
         # insert_external_event is lock-protected, so that is safe.
-        self._rtiamb.connect(self._fed_amb, CallbackModel.HLA_IMMEDIATE)
+        if self._crc:
+            # Local settings designator points the LRC at a (possibly
+            # remote) CRC, e.g. "crcAddress=192.168.1.10:8989".
+            self._rtiamb.connect(
+                self._fed_amb, CallbackModel.HLA_IMMEDIATE,
+                f"crcAddress={self._crc}",
+            )
+        else:
+            self._rtiamb.connect(self._fed_amb, CallbackModel.HLA_IMMEDIATE)
 
     def _build_federate_ambassador(self):
         # JPype cannot subclass a concrete Java class (NullFederateAmbassador),

--- a/pyjevsim/hla/backends/pitch.py
+++ b/pyjevsim/hla/backends/pitch.py
@@ -122,6 +122,12 @@ class PitchTransport(RTIConnector):
         self._reg_enabled = threading.Event()
         self._con_enabled = threading.Event()
 
+        # Federation synchronization points (used to bring multi-process
+        # federations up to a common start barrier). label -> Event.
+        self._sync_lock = threading.Lock()
+        self._sync_announced: dict[str, "threading.Event"] = {}
+        self._sync_done: dict[str, "threading.Event"] = {}
+
         # FOM resolution caches.
         self._ic_handles: dict[str, Any] = {}          # fom_id -> InteractionClassHandle
         self._param_handles: dict[str, dict] = {}      # fom_id -> {field: ParameterHandle}
@@ -189,6 +195,12 @@ class PitchTransport(RTIConnector):
             def reflectAttributeValues(self, theObject, attributes, tag,
                                        *rest):
                 outer._on_reflect(theObject, attributes, rest)
+
+            def announceSynchronizationPoint(self, label, tag):
+                outer._sync_event(outer._sync_announced, str(label)).set()
+
+            def federationSynchronized(self, label, *rest):
+                outer._sync_event(outer._sync_done, str(label)).set()
 
             def __getattr__(self, name):
                 if name.startswith("__"):
@@ -348,6 +360,34 @@ class PitchTransport(RTIConnector):
         self._granted.wait()
         self._logical_time = self._granted_time
         return self._granted_time
+
+    # ------------------------------------------------- synchronization points
+
+    def _sync_event(self, table, label):
+        with self._sync_lock:
+            ev = table.get(label)
+            if ev is None:
+                ev = table[label] = threading.Event()
+            return ev
+
+    def register_sync_point(self, label: str) -> None:
+        """Register a federation synchronization point (one federate calls
+        this; the RTI then announces it to all joined federates)."""
+        tag = self._jpype.JArray(self._jpype.JByte)(0)
+        self._rtiamb.registerFederationSynchronizationPoint(label, tag)
+
+    def wait_sync_announced(self, label: str, timeout: float = 30.0) -> bool:
+        """Block until the RTI announces ``label`` to this federate."""
+        return self._sync_event(self._sync_announced, label).wait(timeout)
+
+    def achieve_sync_point(self, label: str) -> None:
+        """Tell the RTI this federate has reached ``label``."""
+        self._rtiamb.synchronizationPointAchieved(label)
+
+    def wait_synchronized(self, label: str, timeout: float = 30.0) -> bool:
+        """Block until every federate has achieved ``label`` (the RTI then
+        reports the federation as synchronized)."""
+        return self._sync_event(self._sync_done, label).wait(timeout)
 
     # --------------------------------------------------------- FOM handles
 


### PR DESCRIPTION
## What

Adds a **true distributed** ping-pong run: each federate is its own OS
process (own JVM/LRC), joined to one Pitch pRTI federation through the CRC
— not two threads in one process. This backs the distributed-simulation
claim with independent processes coordinated solely by the RTI.

- `pitch.py`: federation **synchronization-point** support
  (`register_sync_point` / `wait_sync_announced` / `achieve_sync_point` /
  `wait_synchronized`) + the matching `announceSynchronizationPoint` /
  `federationSynchronized` ambassador callbacks. Federates share a start
  barrier so neither serves before both have joined and subscribed.
- `examples/hla_pingpong/run_pitch_federate.py`: one federate per process
  (`ping`/`pong` argument).
- `examples/hla_pingpong/run_pitch_multiprocess.py`: launcher that starts
  `pong` (subscriber) first, waits until it has joined+subscribed, then
  starts `ping` (which registers the sync point with both joined), and
  streams both outputs.
- README: distributed (launcher / two-terminal) instructions.

## Verification (live)

Two separate processes, Pitch pRTI Free 5.5.2 + Temurin 11:

```
pong| [pong] received pings: [0, 1, 2, 3]
pong| [pong] reflected hits: [0, 1, 2, 3]
ping| [ping] received pongs: [0, 1, 2, 3]
exit codes: pong=0 ping=0
```

Full suite (hermetic): **110 passed, 2 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)