### PR TITLE
docs: Zenodo archival metadata + CITATION.cff (DOI prep)

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,40 @@
+{
+  "title": "pyjevsim: a Python DEVS modelling and simulation framework with HLA federate support",
+  "description": "pyjevsim is a Python DEVS (Discrete Event System Specification) modelling and simulation framework with journaling (snapshot/restore), virtual- and real-time execution, and HLA (IEEE 1516-2010) federate integration through a pluggable, RTI-agnostic backend interface (validated against Pitch pRTI). It enables DEVS models to participate, unchanged, in distributed and interoperable simulations.",
+  "upload_type": "software",
+  "license": "MIT",
+  "access_right": "open",
+  "creators": [
+    {
+      "name": "Choi, Changbeom",
+      "affiliation": "Hanbat National University"
+    }
+  ],
+  "keywords": [
+    "DEVS",
+    "discrete-event simulation",
+    "modeling and simulation",
+    "HLA",
+    "IEEE 1516",
+    "distributed simulation",
+    "interoperability",
+    "Python"
+  ],
+  "related_identifiers": [
+    {
+      "identifier": "https://github.com/eventsim/pyjevsim",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://pypi.org/project/pyjevsim/",
+      "relation": "isIdenticalTo",
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://pyjevsim.readthedocs.io/",
+      "relation": "isDocumentedBy",
+      "scheme": "url"
+    }
+  ]
+}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,34 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it using these metadata."
+title: pyjevsim
+abstract: >-
+  A Python DEVS (Discrete Event System Specification) modelling and
+  simulation framework with journaling (snapshot/restore), virtual- and
+  real-time execution, and HLA (IEEE 1516-2010) federate integration through
+  a pluggable, RTI-agnostic backend interface (validated against Pitch pRTI).
+type: software
+authors:
+  - family-names: Choi
+    given-names: Changbeom
+    affiliation: Hanbat National University
+    email: me@cbchoi.info
+    # orcid: "https://orcid.org/0000-0000-0000-0000"   # TODO: add ORCID
+repository-code: "https://github.com/eventsim/pyjevsim"
+url: "https://pyjevsim.readthedocs.io/"
+license: MIT
+version: 2.1.1
+date-released: "2026-06-28"
+keywords:
+  - DEVS
+  - discrete-event simulation
+  - modeling and simulation
+  - HLA
+  - IEEE 1516
+  - distributed simulation
+  - Python
+# After enabling the GitHub–Zenodo integration and archiving a release,
+# add the minted DOI here, e.g.:
+# identifiers:
+#   - type: doi
+#     value: "10.5281/zenodo.XXXXXXX"
+#     description: "Concept DOI (all versions)"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Python](https://img.shields.io/pypi/pyversions/pyjevsim.svg)](https://pypi.org/project/pyjevsim/)
 [![Docs](https://readthedocs.org/projects/pyjevsim/badge/?version=latest)](https://pyjevsim.readthedocs.io/en/latest/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![DOI](https://zenodo.org/badge/696591479.svg)](https://zenodo.org/badge/latestdoi/696591479)
 
 ## Introduction
 


### PR DESCRIPTION
## What

Prepares a citable archival DOI (SoftwareX code-metadata **C3**) via the
GitHub–Zenodo integration.

- `.zenodo.json` — Zenodo deposit metadata (title, description, creator,
  license MIT, keywords, related identifiers: GitHub / PyPI / docs).
- `CITATION.cff` — machine-readable citation; powers GitHub's "Cite this
  repository". DOI line to be filled after the first archive.
- `README.md` — Zenodo DOI badge (repo id 696591479); resolves once the
  integration is enabled and a release is archived.

## Maintainer steps to mint the DOI (one-time, web)

1. Sign in at https://zenodo.org with the GitHub account and authorize it.
2. In **zenodo.org → Account → GitHub**, flip the **eventsim/pyjevsim**
   switch **On**.
3. Create a GitHub Release (e.g. the existing `v2.1.1`, or re-publish it) —
   Zenodo archives it and mints a versioned DOI plus a concept DOI.
4. Add the concept DOI to `CITATION.cff` (`identifiers:`) and, if desired,
   replace the badge with the explicit `10.5281/zenodo.XXXXXXX` form.
5. (Optional) add your ORCID to `.zenodo.json` and `CITATION.cff`.

No code changes; safe to merge independently of the HLA work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)