### PR TITLE
chore(release): 2.1.2 — distributed demo, RTI sync points/CRC config, Zenodo metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.2] — 2026-06-28
+
+### Added
+- Distributed (multi-process) HLA ping-pong example: each federate runs as
+  its own OS process (own JVM/LRC) joined to one Pitch pRTI federation
+  (`examples/hla_pingpong/run_pitch_federate.py`,
+  `run_pitch_multiprocess.py`). Federates share a start barrier via a
+  federation synchronization point.
+- `PitchTransport`: federation synchronization-point support
+  (`register_sync_point` / `wait_sync_announced` / `achieve_sync_point` /
+  `wait_synchronized`) and a configurable CRC endpoint
+  (`crc="host:port"`, also via `PYJEVSIM_CRC`) for multi-host federations.
+- Packaging/citation: `.zenodo.json` and `CITATION.cff` for an archival
+  DOI; Zenodo DOI badge in the README.
+
 ## [2.1.1] — 2026-06-28
 
 ### Fixed
@@ -178,7 +193,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `SysExecutor` with V_TIME and R_TIME execution modes, port-based
   coupling, and `dill`-backed serialization.
 
-[Unreleased]: https://github.com/eventsim/pyjevsim/compare/v2.1.1...HEAD
+[Unreleased]: https://github.com/eventsim/pyjevsim/compare/v2.1.2...HEAD
+[2.1.2]: https://github.com/eventsim/pyjevsim/compare/v2.1.1...v2.1.2
 [2.1.1]: https://github.com/eventsim/pyjevsim/compare/v2.1.0...v2.1.1
 [2.1.0]: https://github.com/eventsim/pyjevsim/compare/v2.0.1...v2.1.0
 [2.0.1]: https://github.com/eventsim/pyjevsim/compare/v2.0.0...v2.0.1

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,8 +12,8 @@ sys.path.insert(0, os.path.abspath('../..'))
 project = 'pyjevsim'
 author = 'Changbeom Choi'
 copyright = '2024-2026, Changbeom Choi'
-version = '2.1.1'
-release = '2.1.1'
+version = '2.1.2'
+release = '2.1.2'
 
 extensions = [
     'sphinx.ext.autodoc',      

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyjevsim"
-version = "2.1.1"
+version = "2.1.2"
 description = "A DEVS(Discrete Event System Specification) Modeling & Simulation environment with journaling functionality"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Release **2.1.2**, bundling the recently merged work:

- Distributed (multi-process) HLA ping-pong demo (#18)
- `PitchTransport` synchronization points + configurable CRC endpoint (#18)
- Zenodo archival metadata + `CITATION.cff` (#19)

Changes: `pyproject.toml`, `docs/source/conf.py` → 2.1.2; `CHANGELOG.md` `[2.1.2]`.

Verification: `pytest tests/` → **110 passed, 2 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)