### PR TITLE
docs: record minted Zenodo DOIs (concept + v2.1.2)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -26,9 +26,10 @@ keywords:
   - IEEE 1516
   - distributed simulation
   - Python
-# After enabling the GitHub–Zenodo integration and archiving a release,
-# add the minted DOI here, e.g.:
-# identifiers:
-#   - type: doi
-#     value: "10.5281/zenodo.XXXXXXX"
-#     description: "Concept DOI (all versions)"
+identifiers:
+  - type: doi
+    value: "10.5281/zenodo.21002028"
+    description: "Concept DOI (all versions)"
+  - type: doi
+    value: "10.5281/zenodo.21002029"
+    description: "Version DOI (v2.1.2)"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Python](https://img.shields.io/pypi/pyversions/pyjevsim.svg)](https://pypi.org/project/pyjevsim/)
 [![Docs](https://readthedocs.org/projects/pyjevsim/badge/?version=latest)](https://pyjevsim.readthedocs.io/en/latest/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![DOI](https://zenodo.org/badge/696591479.svg)](https://zenodo.org/badge/latestdoi/696591479)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.21002028.svg)](https://doi.org/10.5281/zenodo.21002028)
 
 ## Introduction
 


### PR DESCRIPTION
Zenodo archived the v2.1.2 release and minted:

- Concept DOI (all versions): 10.5281/zenodo.21002028
- Version DOI (v2.1.2): 10.5281/zenodo.21002029

Updates CITATION.cff identifiers and the README DOI badge (concept form).

🤖 Generated with [Claude Code](https://claude.com/claude-code)