### PR TITLE
docs: add author ORCID to Zenodo/citation metadata

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -7,7 +7,8 @@
   "creators": [
     {
       "name": "Choi, Changbeom",
-      "affiliation": "Hanbat National University"
+      "affiliation": "Hanbat National University",
+      "orcid": "0000-0002-4826-7949"
     }
   ],
   "keywords": [

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
     given-names: Changbeom
     affiliation: Hanbat National University
     email: me@cbchoi.info
-    # orcid: "https://orcid.org/0000-0000-0000-0000"   # TODO: add ORCID
+    orcid: "https://orcid.org/0000-0002-4826-7949"
 repository-code: "https://github.com/eventsim/pyjevsim"
 url: "https://pyjevsim.readthedocs.io/"
 license: MIT


### PR DESCRIPTION
Add ORCID `0000-0002-4826-7949` (Changbeom Choi) to `.zenodo.json` (bare id) and `CITATION.cff` (orcid.org URL). Takes effect on the next Zenodo archive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)