### PR TITLE
feat(examples): hla_atsim — atsim anti-torpedo as two HLA federates

### DIFF
--- a/examples/hla_atsim/.gitignore
+++ b/examples/hla_atsim/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+*.csv

--- a/examples/hla_atsim/README.md
+++ b/examples/hla_atsim/README.md
@@ -1,0 +1,83 @@
+# hla_atsim — HLA co-simulation of the anti-torpedo example
+
+A self-contained HLA/RTI split of `examples/atsim` into **two federates**
+(surfaceship + torpedo) that provably reproduces a single-executor
+reference run, tick-for-tick and bit-for-bit.
+
+## What's here
+
+| file | role |
+|------|------|
+| `run_standalone_headless.py` | single `SysExecutor` reference (writes `standalone_<tag>.csv`) |
+| `run_hla_inprocess.py` | two federates over the in-process RTI bus (writes `hla_<tag>.csv`) — **no Java needed** |
+| `run_hla_pitch.py` | optional live pRTI 1516e run (guarded; writes `hla_pitch_<tag>.csv`) |
+| `verify_equivalence.py` | the gate: runs both headless builds and asserts identical CSVs for every scenario |
+| `fom/AntiTorpedo.xml` | IEEE 1516-2010 FOM, one `Platform` object class |
+| `hla_common.py` | FOM ids, `HLAAttribute` bindings, `ProxySink`, `publish_local` |
+| `scenarios/self_propelled_decoy.yaml` | self-propelled decoy scenario (default) |
+| `scenarios/stationary_decoy.yaml` | stationary decoy scenario |
+| `utils/sim_context.py` | per-federate `SimContext` (replaces the global `ObjectDB` singleton) |
+| `utils/sensing.py` | `PositionSnapshot` + frozen/remote proxies (order-independent sensing) |
+| `utils/ticking.py` | `commit_tick` — tick-boundary decision commit for determinism |
+| `model/`, `mobject/` | atsim models, ctx-injected and made deterministic |
+
+## Run
+
+```bash
+python examples/hla_atsim/verify_equivalence.py
+# -> MATCH self_propelled: 180 rows
+# -> MATCH stationary: 180 rows
+```
+
+The gate verifies **both** scenarios and exits 0 only if both are
+byte-identical. Select a scenario for the individual run scripts via CLI arg
+or the `PYJEVSIM_SCENARIO` env var (defaults to `self_propelled`):
+
+```bash
+python examples/hla_atsim/run_standalone_headless.py stationary   # -> standalone_stationary.csv
+python examples/hla_atsim/run_hla_inprocess.py stationary         # -> hla_stationary.csv
+PYJEVSIM_SCENARIO=stationary python examples/hla_atsim/run_hla_inprocess.py
+```
+
+CSVs are named `standalone_<tag>.csv` / `hla_<tag>.csv` where `<tag>` is the
+scenario key (`self_propelled`, `stationary`); all generated CSVs are gitignored.
+
+## Why standalone == HLA, deterministically
+
+The only cross-platform coupling in atsim is *sensing* (each Detector read
+every other object's position). Two design rules make the split exact and
+reproducible, applied identically to both builds:
+
+1. **1-tick position snapshot.** Detectors (and the CommandControl /
+   TorpedoControl references) read a frozen snapshot taken at the tick
+   boundary — end-of-previous-tick positions — never live mid-tick objects.
+   Iteration is sorted by a stable `sense_id`. In HLA the snapshot is fed by
+   local objects + peer/decoy positions reflected over the RTI with
+   lookahead = 1. See `utils/sensing.py`.
+
+2. **Once-per-tick physics + tick-boundary decision commit.** The atsim
+   models mutate shared physics objects inside `output()`; under DEVS
+   cascades the order and count of `output()` calls at one instant is
+   nondeterministic (`ScheduleQueue.pop()` set-iteration is object-id based).
+   We remove every intra-tick race: each Manuever/decoy integrates exactly
+   once per tick, and cross-model decisions that touch a peer's physics
+   object (heading evasion, pursuit target) are staged as `pending_*` and
+   committed at the next tick boundary. Motion in tick `t` therefore depends
+   only on the tick number and the frozen inputs — identical in one executor
+   or two. See `utils/ticking.py`.
+
+Position exchange is pumped explicitly between `step()` calls
+(`publish_local` → `ProxySink`), not through a bound DEVS "uplink" model, so
+it reads settled end-of-tick positions and stays outside the tick.
+
+## Optional Pitch run
+
+`run_hla_pitch.py` bridges to a real pRTI 1516e CRC. It is **not** part of
+the gate and self-skips unless `jpype`, a JVM, `prti1516e.jar`, and a
+reachable CRC are all present:
+
+```bash
+set PYJEVSIM_JVM=...\jvm.dll
+set PYJEVSIM_JAR=...\prti1516e.jar
+python examples/hla_atsim/run_hla_pitch.py
+```

--- a/examples/hla_atsim/fom/AntiTorpedo.xml
+++ b/examples/hla_atsim/fom/AntiTorpedo.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<objectModel xmlns="http://standards.ieee.org/IEEE1516-2010">
+  <modelIdentification>
+    <name>AntiTorpedo</name>
+    <type>FOM</type>
+    <version>1.0</version>
+    <purpose>Platform position exchange for pyjevsim hla_atsim.</purpose>
+  </modelIdentification>
+
+  <objects>
+    <objectClass>
+      <name>HLAobjectRoot</name>
+      <objectClass>
+        <name>Platform</name>
+        <sharing>PublishSubscribe</sharing>
+        <attribute>
+          <name>id</name>
+          <dataType>HLAunicodeString</dataType>
+          <updateType>Conditional</updateType>
+          <ownership>NoTransfer</ownership>
+          <sharing>PublishSubscribe</sharing>
+          <transportation>HLAreliable</transportation>
+          <order>TimeStamp</order>
+        </attribute>
+        <attribute>
+          <name>kind</name>
+          <dataType>HLAunicodeString</dataType>
+          <updateType>Conditional</updateType>
+          <ownership>NoTransfer</ownership>
+          <sharing>PublishSubscribe</sharing>
+          <transportation>HLAreliable</transportation>
+          <order>TimeStamp</order>
+        </attribute>
+        <attribute>
+          <name>x</name>
+          <dataType>HLAfloat64BE</dataType>
+          <updateType>Conditional</updateType>
+          <ownership>NoTransfer</ownership>
+          <sharing>PublishSubscribe</sharing>
+          <transportation>HLAreliable</transportation>
+          <order>TimeStamp</order>
+        </attribute>
+        <attribute>
+          <name>y</name>
+          <dataType>HLAfloat64BE</dataType>
+          <updateType>Conditional</updateType>
+          <ownership>NoTransfer</ownership>
+          <sharing>PublishSubscribe</sharing>
+          <transportation>HLAreliable</transportation>
+          <order>TimeStamp</order>
+        </attribute>
+        <attribute>
+          <name>z</name>
+          <dataType>HLAfloat64BE</dataType>
+          <updateType>Conditional</updateType>
+          <ownership>NoTransfer</ownership>
+          <sharing>PublishSubscribe</sharing>
+          <transportation>HLAreliable</transportation>
+          <order>TimeStamp</order>
+        </attribute>
+        <attribute>
+          <name>active</name>
+          <dataType>HLAinteger32BE</dataType>
+          <updateType>Conditional</updateType>
+          <ownership>NoTransfer</ownership>
+          <sharing>PublishSubscribe</sharing>
+          <transportation>HLAreliable</transportation>
+          <order>TimeStamp</order>
+        </attribute>
+      </objectClass>
+    </objectClass>
+  </objects>
+
+  <interactions>
+    <interactionClass>
+      <name>HLAinteractionRoot</name>
+    </interactionClass>
+  </interactions>
+
+  <switches>
+    <autoProvide isEnabled="false"/>
+    <conveyRegionDesignatorSets isEnabled="false"/>
+    <conveyProducingFederate isEnabled="false"/>
+    <attributeScopeAdvisory isEnabled="false"/>
+    <attributeRelevanceAdvisory isEnabled="false"/>
+    <objectClassRelevanceAdvisory isEnabled="false"/>
+    <interactionRelevanceAdvisory isEnabled="false"/>
+    <serviceReporting isEnabled="false"/>
+    <exceptionReporting isEnabled="false"/>
+    <delaySubscriptionEvaluation isEnabled="false"/>
+    <automaticResignAction resignAction="CancelThenDeleteThenDivest"/>
+  </switches>
+</objectModel>

--- a/examples/hla_atsim/hla_common.py
+++ b/examples/hla_atsim/hla_common.py
@@ -1,0 +1,71 @@
+"""Shared HLA descriptors for hla_atsim: FOM ids, bindings, ProxySink, publish.
+
+The Platform attribute carries a whole physics object's end-of-tick state.
+Both federates publish and subscribe the same ``fom_id``; the in-process bus
+excludes the sender from a broadcast, so a federate never reflects its own
+updates.
+"""
+
+from pyjevsim.hla import HLAAttribute
+from utils.sensing import RemoteObject
+
+PLATFORM_FOM = "AntiTorpedo.Platform"
+
+PLATFORM_OUT = HLAAttribute(PLATFORM_FOM, direction="out", object_class="Platform")
+PLATFORM_IN = HLAAttribute(PLATFORM_FOM, direction="in")
+
+# FOM map for the Pitch backend (handle resolution + field encoding).
+ANTITORPEDO_FOM_MAP = {
+    PLATFORM_FOM: {
+        "kind": "attribute",
+        "class": "HLAobjectRoot.Platform",
+        "fields": {
+            "id": "string",
+            "kind": "string",
+            "x": "float64",
+            "y": "float64",
+            "z": "float64",
+            "active": "int32",
+        },
+    },
+}
+
+
+class ProxySink:
+    """Duck-typed router subscriber (has ``_on_rti_event``).
+
+    Synchronously upserts reflected peers into ``ctx.remote`` — NOT via
+    ``insert_external_event`` — so the position exchange stays *outside*
+    the DEVS tick and equivalence with standalone is exact.
+    """
+
+    def __init__(self, ctx):
+        self.ctx = ctx
+
+    def _on_rti_event(self, kind, fom_id, payload, timestamp):
+        d = payload[0]
+        sid = d["id"]
+        if int(d["active"]) == 0:
+            self.ctx.remote.pop(sid, None)
+        else:
+            self.ctx.remote[sid] = RemoteObject(
+                sid, d["kind"], d["x"], d["y"], d["z"], True
+            )
+
+
+def publish_local(ctx, transport):
+    """Broadcast every local object's end-of-tick position, plus active=0
+    tombstones for objects pruned since the last publish."""
+    for o in ctx.items:
+        x, y, z = o.get_position()
+        transport.send(PLATFORM_OUT, [{
+            "id": o.sense_id, "kind": o.kind,
+            "x": x, "y": y, "z": z,
+            "active": 1 if o.check_active() else 0,
+        }])
+    for sid in ctx.removed:
+        transport.send(PLATFORM_OUT, [{
+            "id": sid, "kind": "decoy",
+            "x": 0.0, "y": 0.0, "z": 0.0, "active": 0,
+        }])
+    ctx.removed.clear()

--- a/examples/hla_atsim/mobject/comand_control_object.py
+++ b/examples/hla_atsim/mobject/comand_control_object.py
@@ -1,0 +1,22 @@
+import math
+
+class CommandControlObject:
+	def __init__(self, evation_heading, decoy_deployment_range):
+		self.evation_heading = evation_heading
+		self.deployment_range = decoy_deployment_range
+
+
+	def get_evasion_heading(self):
+		return self.evation_heading
+
+	def threat_evaluation(self, ref_obj, target_obj):
+		sx, sy, sz = ref_obj.get_position()
+		tx, ty, tz = target_obj.get_position()
+
+		#print( math.sqrt((sx-tx)**2 + (sy-ty)**2 + (sz-tz)**2), self.deployment_range)
+
+		if math.sqrt((sx-tx)**2 + (sy-ty)**2 + (sz-tz)**2) <= self.deployment_range:
+			return True
+		else:
+			return False
+	

--- a/examples/hla_atsim/mobject/detector_object.py
+++ b/examples/hla_atsim/mobject/detector_object.py
@@ -1,0 +1,16 @@
+import math
+
+class DetectorObject:
+	def __init__(self, detection_range):
+		self.detect_range = detection_range
+
+	def detect(self, ref_obj, target_obj):
+		sx, sy, sz = ref_obj.get_position()
+		tx, ty, tz = target_obj.get_position()
+
+		#print( math.sqrt((sx-tx)**2 + (sy-ty)**2 + (sz-tz)**2), self.detect_range)
+
+		if math.sqrt((sx-tx)**2 + (sy-ty)**2 + (sz-tz)**2) <= self.detect_range:
+			return True
+		else:
+			return False

--- a/examples/hla_atsim/mobject/launcher_object.py
+++ b/examples/hla_atsim/mobject/launcher_object.py
@@ -1,0 +1,27 @@
+import math
+
+class LauncherObject:
+	def __init__(self, DecoyObjects):
+		self.decoy_list = DecoyObjects
+
+	def get_decoy_list(self):
+		return self.decoy_list
+	
+	def get_decoy_count(self):
+		return len(self.decoy_list)
+
+	def get_time_of_flight(self, decoy, init_height= 0, g = 9.8):
+		speed = decoy['speed'] 
+		elevation_deg = decoy['elevation']
+
+		# Convert degrees to radians for trigonometric functions
+		theta = math.radians(elevation_deg)
+
+		# Initial vertical velocity component
+		v_z0 = speed * math.sin(theta)
+
+		# Quadratic discriminant for z(t) = 0
+		discriminant = v_z0**2 + 2 * g * init_height
+
+		# Positive root gives the physical flight time
+		return (v_z0 + math.sqrt(discriminant)) / g

--- a/examples/hla_atsim/mobject/manuever_object.py
+++ b/examples/hla_atsim/mobject/manuever_object.py
@@ -1,0 +1,79 @@
+import math
+
+class ManueverObject:
+	def __init__(self, x, y, z, heading, xy_speed, z_speed):
+		self.x = x
+		self.y = y
+		self.z = z
+		self.heading = heading
+		self.xy_speed = xy_speed
+		self.z_speed = z_speed
+		self.active = True
+
+	def check_active(self):
+		return self.active
+
+	def get_position(self):
+		return (self.x, self.y, self.z)
+
+	def change_z_speed(self, z_spd):
+		self.z_speed = z_spd
+
+	def change_speed(self, speed):
+		self.xy_speed = speed
+
+	def change_heading(self, heading):
+		self.heading = heading
+
+	def calc_next_pos_with_heading(self, dt):
+		#print("h", self.x, self.y, self.z)
+		# Convert heading from degrees to radians
+		heading_radians = math.radians(self.heading)
+
+		# Calculate x and y positions
+		# In this coordinate system: x is based on sin, y is based on cos
+		self.x += dt * self.xy_speed * math.sin(heading_radians)
+		self.y += dt * self.xy_speed * math.cos(heading_radians)
+		self.z += dt * self.z_speed
+		if self.z >= 0:
+			self.z = 0
+
+	def calc_next_pos_with_pos(self, target, dt):
+		#print("p", self.x, self.y, self.z)
+		# Calculate the vector from current position to target
+		dx = target[0] - self.x
+		dy = target[1] - self.y
+		dz = target[2] - self.z
+
+		# Calculate the horizontal distance and total 3D distance
+		horizontal_distance = math.sqrt(dx**2 + dy**2)
+
+		# Calculate the maximum distance the object can move during dt
+		xy_move_distance = dt * self.xy_speed
+		z_move_distance = dt * self.z_speed
+
+
+		if horizontal_distance <= xy_move_distance:
+			# If the target is within reach, move directly to the target
+			self.x = target[0]
+			self.y = target[1]
+		else:
+			# Calculate horizontal heading using atan2
+			heading_radians = math.atan2(dx, dy)  # Note: (x, y) order because 0° = North, increases clockwise
+
+			# Calculate movement in x and y
+			move_xy_distance = min(horizontal_distance, xy_move_distance)
+
+			move_x = move_xy_distance * math.sin(heading_radians)
+			move_y = move_xy_distance * math.cos(heading_radians)
+
+			self.x += move_x
+			self.y += move_y
+
+		if dz <= z_move_distance:
+			self.z = target[2]
+		else:
+			self.z += z_move_distance
+
+		return z_move_distance + xy_move_distance
+			

--- a/examples/hla_atsim/mobject/self_propelled_decoy_object.py
+++ b/examples/hla_atsim/mobject/self_propelled_decoy_object.py
@@ -1,0 +1,96 @@
+import math
+
+class SelfPropelledDecoyObject:
+	def __init__(self, pos, decoy_info):
+		self.x, self.y, self.z = pos
+		self.g = 9.8
+		self.elevation			= decoy_info['elevation']
+		self.azimuth			= decoy_info['azimuth']
+		self.launch_speed		= decoy_info['speed']
+		self.z_speed			= decoy_info['speed']
+		self.lifespan			= decoy_info['lifespan']
+		self.heading			= decoy_info['heading']
+		self.xy_speed			= decoy_info['xy_speed']
+		self.active				= True
+		self.propelled_mode		= False
+		self.time_of_flight		= self.get_time_of_flight()
+
+	def get_position(self):
+		return (self.x, self.y, self.z)
+
+	def set_decoy_info(self, pos, decoy_info):
+		self.x, self.y, self.z = pos
+		self.g = 9.8
+		self.elevation			= decoy_info['elevation']
+		self.azimuth			= decoy_info['azimuth']
+		self.launch_speed		= decoy_info['speed']
+		self.z_speed			= decoy_info['speed']
+		self.lifespan			= decoy_info['lifespan']
+		self.heading			= decoy_info['heading']
+		self.xy_speed			= decoy_info['xy_speed']
+  
+	def check_flight(self, dt):
+		self.time_of_flight -= dt
+		if self.time_of_flight < 0:
+			return False
+		else:
+			return True
+
+	def check_lifespan(self, dt):
+		self.lifespan -= dt
+		if self.lifespan < 0:
+			self.active = False
+			return False
+		else:
+			self.active = True
+			return True
+
+	def check_active(self):
+		return self.active
+
+	def calc_next_pos(self, dt):
+		if not self.propelled_mode :
+			 # Convert degrees to radians
+			theta = math.radians(self.elevation)
+			phi   = math.radians(self.azimuth)
+		    
+			vx0 = self.launch_speed * math.cos(theta) * math.sin(phi)
+			vy0 = self.launch_speed * math.cos(theta) * math.cos(phi)
+			vz0 = self.z_speed * math.sin(theta)
+
+			self.x = self.x + vx0 * dt
+			self.y = self.y + vy0 * dt
+			self.z = self.z + vz0 * dt - 0.5 * self.g * dt**2
+		
+			if self.z < 0:
+				self.z = 0
+				self.propelled_mode = True
+
+			if self.z_speed >= 0:
+				self.z_speed -= self.g * dt
+		else:
+			self.calc_next_pos_with_heading(dt)
+
+	def calc_next_pos_with_heading(self, dt):
+		#print("h", self.x, self.y, self.z)
+		# Convert heading from degrees to radians
+		heading_radians = math.radians(self.heading)
+
+		# Calculate x and y positions
+		# In this coordinate system: x is based on sin, y is based on cos
+		self.x += dt * self.xy_speed * math.sin(heading_radians)
+		self.y += dt * self.xy_speed * math.cos(heading_radians)
+  
+	
+	def get_time_of_flight(self, init_height= 0, g = 9.8):
+		# Convert degrees to radians for trigonometric functions
+		theta = math.radians(self.elevation)
+
+		# Initial vertical velocity component
+		v_z0 = self.launch_speed * math.sin(theta)
+
+		# Quadratic discriminant for z(t) = 0
+		discriminant = v_z0**2 + 2 * g * init_height
+
+		# Positive root gives the physical flight time
+		return (v_z0 + math.sqrt(discriminant)) / g

--- a/examples/hla_atsim/mobject/stationary_decoy_object.py
+++ b/examples/hla_atsim/mobject/stationary_decoy_object.py
@@ -1,0 +1,76 @@
+import math
+
+class StationaryDecoyObject:
+	def __init__(self, pos, decoy_info):
+		self.x, self.y, self.z = pos
+		self.g = 9.8
+		self.elevation		  = decoy_info['elevation']
+		self.azimuth		  = decoy_info['azimuth']
+		self.launch_speed     = decoy_info['speed']
+		self.z_speed		  = decoy_info['speed']
+		self.lifespan		  = decoy_info['lifespan']
+		self.active			  = True
+		self.time_of_flight		= self.get_time_of_flight()
+
+	def get_position(self):
+		return (self.x, self.y, self.z)
+
+	def set_decoy_info(self, decoy_info):
+		self.elevation			= decoy_info['elevation']
+		self.azimuth			= decoy_info['azimuth']
+		self.launch_speed		= decoy_info['speed']
+		self.z_speed			= decoy_info['speed']
+		self.lifespan			= decoy_info['lifespan']
+		self.heading			= decoy_info['heading']
+		self.xy_speed			= decoy_info['xy_speed']
+
+	def check_flight(self, dt):
+		self.time_of_flight -= dt
+		if self.time_of_flight < 0:
+			return False
+		else:
+			return True
+
+	def check_lifespan(self, dt):
+		self.lifespan -= dt
+		if self.lifespan < 0:
+			self.active = False
+			return False
+		else:
+			self.active = True
+			return True
+
+	def check_active(self):
+		return self.active
+
+	def calc_next_pos(self, dt):
+		 # Convert degrees to radians
+		theta = math.radians(self.elevation)
+		phi   = math.radians(self.azimuth)
+		    
+		vx0 = self.launch_speed * math.cos(theta) * math.sin(phi)
+		vy0 = self.launch_speed * math.cos(theta) * math.cos(phi)
+		vz0 = self.z_speed * math.sin(theta)
+
+		self.x = self.x + vx0 * dt
+		self.y = self.y + vy0 * dt
+		self.z = self.z + vz0 * dt - 0.5 * self.g * dt**2
+		
+		if self.z < 0:
+			self.z = 0
+
+		if self.z_speed >= 0:
+			self.z_speed -= self.g * dt
+
+	def get_time_of_flight(self, init_height= 0, g = 9.8):
+		# Convert degrees to radians for trigonometric functions
+		theta = math.radians(self.elevation)
+
+		# Initial vertical velocity component
+		v_z0 = self.launch_speed * math.sin(theta)
+
+		# Quadratic discriminant for z(t) = 0
+		discriminant = v_z0**2 + 2 * g * init_height
+
+		# Positive root gives the physical flight time
+		return (v_z0 + math.sqrt(discriminant)) / g

--- a/examples/hla_atsim/mobject/torpedo_control_object.py
+++ b/examples/hla_atsim/mobject/torpedo_control_object.py
@@ -1,0 +1,27 @@
+import math
+
+class TorpedoControlObject:
+	def __init__(self, range):
+		self.prev_target = None
+		self.range = range
+		pass
+
+	def reset_target(self):
+		self.prev_target = None
+
+	def get_target(self, ref_obj, target):
+		
+		if not self.prev_target:
+			self.prev_target = target
+
+		sx, sy, sz = ref_obj.get_position()
+		tx, ty, tz = target.get_position()
+		px, py, pz = self.prev_target.get_position()
+
+		new_dist = math.sqrt((sx-tx)**2 + (sy-ty)**2 + (sz-tz)**2)
+		prev_dist = math.sqrt((sx-px)**2 + (sy-py)**2 + (sz-pz)**2)
+		
+		if prev_dist > new_dist:
+			self.prev_target = target
+
+		return self.prev_target.get_position()

--- a/examples/hla_atsim/model/command_control.py
+++ b/examples/hla_atsim/model/command_control.py
@@ -1,0 +1,48 @@
+import platform
+from pyjevsim import BehaviorModel, Infinite
+import datetime
+
+from pyjevsim.system_message import SysMessage
+
+class CommandControl(BehaviorModel):
+    def __init__(self, name, platform):
+        BehaviorModel.__init__(self, name)
+        
+        self.platform = platform
+        
+        self.init_state("Wait")
+        self.insert_state("Wait", Infinite)
+        self.insert_state("Decision", 0)
+
+        self.insert_input_port("threat_list")
+        self.insert_output_port("launch_order")
+
+
+        self.threat_list = []
+
+    def ext_trans(self,port, msg):
+        if port == "threat_list":
+            print(f"{self.get_name()}[threat_list]: {datetime.datetime.now()}")
+            self.threat_list = msg.retrieve()[0]
+            self._cur_state = "Decision"
+
+    def output(self, msg_deliver):
+        # Reference from the frozen snapshot (order-independent), like the
+        # Detector. The heading change is staged as pending_heading and
+        # committed at the next tick boundary (see utils/ticking.py) so it
+        # cannot race the Manuever integration within this tick.
+        snap = self.platform.ctx.snapshot
+        me = snap.get(self.platform.sense_id)
+        for target in self.threat_list:
+            if me is not None and self.platform.co.threat_evaluation(me, target):
+                # send order
+                message = SysMessage(self.get_name(), "launch_order")
+                msg_deliver.insert_message(message)
+                # stage evasion heading (applied next tick)
+                self.platform.mo.pending_heading = self.platform.co.get_evasion_heading()
+
+        self.threat_list = []
+        
+    def int_trans(self):
+        if self._cur_state == "Decision":
+            self._cur_state = "Wait"

--- a/examples/hla_atsim/model/detector.py
+++ b/examples/hla_atsim/model/detector.py
@@ -1,0 +1,47 @@
+import project_config
+from pyjevsim import BehaviorModel, Infinite
+import datetime
+
+from pyjevsim.system_message import SysMessage
+
+
+class Detector(BehaviorModel):
+    def __init__(self, name, platform):
+        BehaviorModel.__init__(self, name)
+
+        self.platform = platform
+
+        self.init_state("Wait")
+        self.insert_state("Wait", Infinite)
+        self.insert_state("Detect", 1)
+
+        self.insert_input_port("start")
+        self.insert_output_port("threat_list")
+
+    def ext_trans(self, port, msg):
+        if port == "start":
+            print(f"{self.get_name()}[start_recv]: {datetime.datetime.now()}")
+            self._cur_state = "Detect"
+
+    def output(self, msg_deliver):
+        message = SysMessage(self.get_name(), "threat_list")
+        message.insert([])
+
+        # Read the frozen end-of-previous-tick snapshot, never live objects.
+        snap = self.platform.ctx.snapshot
+        me = snap.get(self.platform.sense_id)
+        if me is None:
+            return
+
+        for target in snap.entries():                 # sorted by sense_id
+            if target.sense_id == self.platform.sense_id:
+                continue
+            if target.check_active() and self.platform.do.detect(me, target):
+                message.retrieve()[0].append(target)  # FrozenProxy (has get_position)
+
+        if message.retrieve()[0]:
+            msg_deliver.insert_message(message)
+
+    def int_trans(self):
+        if self._cur_state == "Detect":
+            self._cur_state = "Detect"

--- a/examples/hla_atsim/model/launcher.py
+++ b/examples/hla_atsim/model/launcher.py
@@ -1,0 +1,65 @@
+import datetime
+import math
+
+from pyjevsim import BehaviorModel, Infinite
+
+from .stationary_decoy import StationaryDecoy
+from .self_propelled_decoy import SelfPropelledDecoy
+from mobject.stationary_decoy_object import StationaryDecoyObject
+from mobject.self_propelled_decoy_object import SelfPropelledDecoyObject
+
+
+class Launcher(BehaviorModel):
+    def __init__(self, name, platform):
+        BehaviorModel.__init__(self, name)
+
+        self.platform = platform
+
+        self.init_state("Wait")
+        self.insert_state("Wait", Infinite)
+        self.insert_state("Launch", 0)
+
+        self.insert_input_port("order")
+
+        self.launch_flag = False
+
+    def ext_trans(self, port, msg):
+        if port == "order":
+            print(f"{self.get_name()}[order_recv]: {datetime.datetime.now()}")
+            self._cur_state = "Launch"
+
+    def output(self, msg_deliver):
+        if not self.launch_flag:
+            ctx = self.platform.ctx
+            se = ctx.get_executor()
+
+            # Spawn from the ship's frozen snapshot position (start-of-tick),
+            # so the launch site does not depend on whether the ship Manuever
+            # fired before or after the Launcher within this tick.
+            me = ctx.snapshot.get(self.platform.sense_id)
+            spawn_pos = me.get_position() if me is not None else self.platform.get_position()
+
+            for idx, decoy in enumerate(self.platform.lo.get_decoy_list()):
+                destroy_t = math.ceil(decoy['lifespan'])
+                sid = f"{self.platform.sense_id}::decoy_{idx}"
+
+                if decoy["type"] == "stationary":
+                    sdo = StationaryDecoyObject(spawn_pos, decoy)
+                    decoy_model = StationaryDecoy(sid, sdo, ctx)
+                elif decoy["type"] == "self_propelled":
+                    sdo = SelfPropelledDecoyObject(spawn_pos, decoy)
+                    decoy_model = SelfPropelledDecoy(sid, sdo, ctx)
+                else:
+                    continue
+
+                sdo.sense_id = sid
+                sdo.kind = "decoy"
+                ctx.decoys.append((sid, sdo))
+                ctx.items.append(sdo)
+                se.register_entity(decoy_model, 0, destroy_t)
+
+        self.launch_flag = True
+
+    def int_trans(self):
+        if self._cur_state == "Launch":
+            self._cur_state = "Wait"

--- a/examples/hla_atsim/model/manuever.py
+++ b/examples/hla_atsim/model/manuever.py
@@ -1,0 +1,35 @@
+from pyjevsim import BehaviorModel, Infinite
+import datetime
+
+
+class Manuever(BehaviorModel):
+    def __init__(self, name, platform):
+        BehaviorModel.__init__(self, name)
+
+        self.platform = platform
+
+        self.init_state("Wait")
+        self.insert_state("Wait", Infinite)
+        self.insert_state("Generate", 1)
+
+        self.insert_input_port("start")
+
+        self._last_tick = None
+
+    def ext_trans(self, port, msg):
+        if port == "start":
+            print(f"{self.get_name()}[start_recv]: {datetime.datetime.now()}")
+            self._cur_state = "Generate"
+
+    def output(self, msg_deliver):
+        # Once-per-tick integration: the number/order of output() calls
+        # within a tick must not change the physics (see utils/ticking.py).
+        tick = self.platform.ctx.tick
+        if self._last_tick == tick:
+            return
+        self._last_tick = tick
+        self.platform.mo.calc_next_pos_with_heading(1)
+
+    def int_trans(self):
+        if self._cur_state == "Generate":
+            self._cur_state = "Generate"

--- a/examples/hla_atsim/model/self_propelled_decoy.py
+++ b/examples/hla_atsim/model/self_propelled_decoy.py
@@ -1,0 +1,36 @@
+from pyjevsim import BehaviorModel, Infinite
+import datetime
+
+
+class SelfPropelledDecoy(BehaviorModel):
+    def __init__(self, name, platform, ctx):
+        BehaviorModel.__init__(self, name)
+
+        self.platform = platform
+        self.ctx = ctx
+
+        self.init_state("Maneuver")
+        self.insert_state("Maneuver", 1)
+
+        self._last_tick = None
+
+    def ext_trans(self, port, msg):
+        pass
+
+    def output(self, msg_deliver):
+        # Once-per-tick integration: calc_next_pos and the check_lifespan/
+        # check_flight decrements must happen exactly once per tick.
+        tick = self.ctx.tick
+        if self._last_tick == tick:
+            return
+        self._last_tick = tick
+
+        self.platform.calc_next_pos(1)
+        if not self.platform.check_lifespan(1) and not self.platform.check_flight(1):
+            if self.platform in self.ctx.items:
+                self.ctx.items.remove(self.platform)
+                self.ctx.removed.append(self.platform.sense_id)
+
+    def int_trans(self):
+        if self._cur_state == "Maneuver":
+            self._cur_state = "Maneuver"

--- a/examples/hla_atsim/model/stationary_decoy.py
+++ b/examples/hla_atsim/model/stationary_decoy.py
@@ -1,0 +1,35 @@
+from pyjevsim import BehaviorModel, Infinite
+import datetime
+
+
+class StationaryDecoy(BehaviorModel):
+    def __init__(self, name, platform, ctx):
+        BehaviorModel.__init__(self, name)
+
+        self.platform = platform
+        self.ctx = ctx
+
+        self.init_state("Maneuver")
+        self.insert_state("Maneuver", 1)
+
+        self._last_tick = None
+
+    def ext_trans(self, port, msg):
+        pass
+
+    def output(self, msg_deliver):
+        # Once-per-tick integration (order-independent).
+        tick = self.ctx.tick
+        if self._last_tick == tick:
+            return
+        self._last_tick = tick
+
+        self.platform.calc_next_pos(1)
+        if not self.platform.check_lifespan(1) and not self.platform.check_flight(1):
+            if self.platform in self.ctx.items:
+                self.ctx.items.remove(self.platform)
+                self.ctx.removed.append(self.platform.sense_id)
+
+    def int_trans(self):
+        if self._cur_state == "Maneuver":
+            self._cur_state = "Maneuver"

--- a/examples/hla_atsim/model/surfaceship.py
+++ b/examples/hla_atsim/model/surfaceship.py
@@ -1,0 +1,58 @@
+import project_config
+
+from pyjevsim import StructuralModel, Infinite
+
+from .manuever import Manuever
+from mobject.manuever_object import ManueverObject
+
+from .detector import Detector
+from mobject.detector_object import DetectorObject
+
+from .command_control import CommandControl
+from mobject.comand_control_object import CommandControlObject
+
+from .launcher import Launcher
+from mobject.launcher_object import LauncherObject
+
+
+class SurfaceShip(StructuralModel):
+    def __init__(self, name, yaml_data, ctx):
+        StructuralModel.__init__(self, name)
+
+        self.ctx = ctx
+        self.sense_id = name
+
+        # Model Object Instantiation
+        self.mo = ManueverObject(**yaml_data["ManueverObject"])
+        self.do = DetectorObject(**yaml_data["DetectorObject"])
+        self.co = CommandControlObject(**yaml_data["CommandControlObject"])
+        self.lo = LauncherObject(**yaml_data["LauncherObject"])
+
+        # Register this platform's physics object with the sim context.
+        self.mo.sense_id = name
+        self.mo.kind = "ship"
+        ctx.items.append(self.mo)
+
+        # Model Instantiation
+        man = Manuever(f"[{name}][Manuever]", self)
+        detect = Detector(f"[{name}][Detector]", self)
+        command = CommandControl(f"[{name}][ComandControl]", self)
+        launcher = Launcher(f"[{name}][Launcher]", self)
+
+        # Model Registration
+        self.register_entity(man)
+        self.register_entity(detect)
+        self.register_entity(command)
+        self.register_entity(launcher)
+
+        # Port Registration
+        self.insert_input_port("start")
+
+        # Coupling Handling
+        self.coupling_relation(self, "start", man, "start")
+        self.coupling_relation(self, "start", detect, "start")
+        self.coupling_relation(detect, "threat_list", command, "threat_list")
+        self.coupling_relation(command, "launch_order", launcher, "order")
+
+    def get_position(self):
+        return self.mo.get_position()

--- a/examples/hla_atsim/model/torpedo.py
+++ b/examples/hla_atsim/model/torpedo.py
@@ -1,0 +1,51 @@
+import project_config
+
+from pyjevsim import StructuralModel, Infinite
+
+from .tracking_manuever import TrackingManuever as Manuever
+from mobject.manuever_object import ManueverObject
+
+from .detector import Detector
+from mobject.detector_object import DetectorObject
+
+from .torpedo_controller import TorpedoCommandControl as CommandControl
+from mobject.torpedo_control_object import TorpedoControlObject
+
+
+class Torpedo(StructuralModel):
+    def __init__(self, name, yaml_data, ctx):
+        StructuralModel.__init__(self, name)
+
+        self.ctx = ctx
+        self.sense_id = name
+
+        # Model Object Instantiation
+        self.mo = ManueverObject(**yaml_data["ManueverObject"])
+        self.do = DetectorObject(**yaml_data["DetectorObject"])
+        self.co = TorpedoControlObject(**yaml_data["TorpedoControlObject"])
+
+        self.mo.sense_id = name
+        self.mo.kind = "torpedo"
+        ctx.items.append(self.mo)
+
+        # Model Instantiation
+        man = Manuever(f"[{name}][Manuever]", self)
+        detect = Detector(f"[{name}][Detector]", self)
+        command = CommandControl(f"[{name}][ComandControl]", self)
+
+        # Model Registration
+        self.register_entity(man)
+        self.register_entity(detect)
+        self.register_entity(command)
+
+        # Port Registration
+        self.insert_input_port("start")
+
+        # Coupling Handling
+        self.coupling_relation(self, "start", man, "start")
+        self.coupling_relation(self, "start", detect, "start")
+        self.coupling_relation(detect, "threat_list", command, "threat_list")
+        self.coupling_relation(command, "target", man, "target")
+
+    def get_position(self):
+        return self.mo.get_position()

--- a/examples/hla_atsim/model/torpedo_controller.py
+++ b/examples/hla_atsim/model/torpedo_controller.py
@@ -1,0 +1,50 @@
+import platform
+from pyjevsim import BehaviorModel, Infinite
+import datetime
+
+from pyjevsim.system_message import SysMessage
+
+class TorpedoCommandControl(BehaviorModel):
+    def __init__(self, name, platform):
+        BehaviorModel.__init__(self, name)
+        
+        self.platform = platform
+        
+        self.init_state("Wait")
+        self.insert_state("Wait", Infinite)
+        self.insert_state("Decision", 0)
+
+        self.insert_input_port("threat_list")
+        self.insert_output_port("target")
+        self.threat_list = []
+
+    def ext_trans(self,port, msg):
+        if port == "threat_list":
+            print(f"{self.get_name()}[threat_list]: {datetime.datetime.now()}")
+            self.threat_list = msg.retrieve()[0]
+            self._cur_state = "Decision"
+
+    def output(self, msg_deliver):
+        # Reference from the frozen snapshot (order-independent). The pursuit
+        # target is staged as pending_target and committed at the next tick
+        # boundary (see utils/ticking.py), so TrackingManuever reads it
+        # deterministically instead of via a live message that used
+        # cancel_rescheduling (a source of intra-tick nondeterminism).
+        snap = self.platform.ctx.snapshot
+        me = snap.get(self.platform.sense_id)
+        target = None
+
+        if me is not None:
+            for t in self.threat_list:
+                target = self.platform.co.get_target(me, t)
+
+        # house keeping
+        self.threat_list = []
+        self.platform.co.reset_target()
+
+        if target:
+            self.platform.mo.pending_target = target
+        
+    def int_trans(self):
+        if self._cur_state == "Decision":
+            self._cur_state = "Wait"

--- a/examples/hla_atsim/model/tracking_manuever.py
+++ b/examples/hla_atsim/model/tracking_manuever.py
@@ -1,0 +1,47 @@
+from pyjevsim import BehaviorModel, Infinite
+import datetime
+
+
+class TrackingManuever(BehaviorModel):
+    def __init__(self, name, platform):
+        BehaviorModel.__init__(self, name)
+
+        self.platform = platform
+
+        self.init_state("Wait")
+        self.insert_state("Wait", Infinite)
+        self.insert_state("Manuever", 1)
+
+        self.insert_input_port("start")
+        self.insert_input_port("target")
+
+        self.idx = 0
+        self._last_tick = None
+
+    def ext_trans(self, port, msg):
+        if port == "start":
+            print(f"{self.get_name()}[start_recv]: {datetime.datetime.now()}")
+            self._cur_state = "Manuever"
+        # The "target" port is retained for coupling compatibility but is no
+        # longer the pursuit path: the target is committed to the physics
+        # object at the tick boundary (see utils/ticking.py), so motion is
+        # order-independent. Live target messages (which used
+        # cancel_rescheduling) reintroduced intra-tick nondeterminism.
+
+    def output(self, msg_deliver):
+        # Once-per-tick integration (order-independent).
+        tick = self.platform.ctx.tick
+        if self._last_tick == tick:
+            return
+        self._last_tick = tick
+        self.idx += 1
+
+        target = getattr(self.platform.mo, "committed_target", None)
+        if target is not None:
+            self.platform.mo.calc_next_pos_with_pos(target, 1)
+        else:
+            self.platform.mo.calc_next_pos_with_heading(1)
+
+    def int_trans(self):
+        if self._cur_state == "Manuever":
+            self._cur_state = "Manuever"

--- a/examples/hla_atsim/project_config.py
+++ b/examples/hla_atsim/project_config.py
@@ -1,0 +1,5 @@
+import sys
+import os
+
+# Add parent directory to sys.path
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))

--- a/examples/hla_atsim/run_hla_inprocess.py
+++ b/examples/hla_atsim/run_hla_inprocess.py
@@ -1,0 +1,116 @@
+"""HLA in-process run: two federates (surfaceship + torpedo) in lockstep.
+
+No Java / pRTI required. Two SysExecutors join one InProcessFederation and
+exchange Platform positions with lookahead = 1 tick via an explicit
+tick-boundary pipeline. Produces a CSV identical to the standalone run.
+
+Run:  python examples/hla_atsim/run_hla_inprocess.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+sys.path.insert(0, os.path.dirname(__file__))
+
+from pyjevsim import ExecutionType, SysExecutor  # noqa: E402
+from pyjevsim.hla import (  # noqa: E402
+    Federate,
+    HLAExecutorFactory,
+    InProcessFederation,
+    InProcessRTI,
+)
+
+from utils.sim_context import SimContext  # noqa: E402
+from utils.builder import load_scenario, build_ship, build_torpedo  # noqa: E402
+from utils.ticking import commit_tick  # noqa: E402
+from hla_common import (  # noqa: E402
+    PLATFORM_FOM,
+    PLATFORM_OUT,
+    PLATFORM_IN,
+    ProxySink,
+    publish_local,
+)
+from run_standalone_headless import record, SCENARIO, TICKS, resolve_scenario  # noqa: E402
+
+FOM = os.path.join(os.path.dirname(__file__), "fom", "AntiTorpedo.xml")
+
+
+def build_fed(fed_name, model, ctx, federation):
+    se = SysExecutor(_time_resolution=1, ex_mode=ExecutionType.HLA_TIME)
+    ctx.set_executor(se)
+
+    tx = InProcessRTI(federation=federation)
+    # Empty bindings -> every model gets a plain BehaviorExecutor (pure DEVS);
+    # position exchange is pumped explicitly at the tick boundary.
+    se.exec_factory = HLAExecutorFactory(tx, {})
+
+    se.insert_input_port("start")
+    se.register_entity(model)
+    se.coupling_relation(se, "start", model, "start")
+    se.init_sim()
+    se.insert_external_event("start", None)
+
+    fed = Federate(se, tx)
+    fed.join("AntiTorpedo", fed_name, fom_paths=[FOM])
+    fed.publish(PLATFORM_OUT)
+    fed.subscribe(PLATFORM_IN)
+
+    # Reuse the factory's router; add a synchronous proxy sink that upserts
+    # reflected peer/decoy positions into ctx.remote.
+    se.exec_factory._router.subscribe("attribute", PLATFORM_FOM, ProxySink(ctx))
+    return se, tx, fed
+
+
+def run(scenario=SCENARIO):
+    federation = InProcessFederation("AntiTorpedo")
+    data = load_scenario(scenario)
+
+    ship_ctx, torp_ctx = SimContext(), SimContext()
+    ship = build_ship("blue_ship_0", data["SurfaceShip"][0], ship_ctx)
+    torp = build_torpedo("red_torpedo_0", data["Torpedo"][0], torp_ctx)
+
+    ship_se, ship_tx, ship_fed = build_fed("ship", ship, ship_ctx, federation)
+    torp_se, torp_tx, torp_fed = build_fed("torpedo", torp, torp_ctx, federation)
+    print(f"federation members after join: {len(federation.members)}")
+
+    rows = []
+    for t in range(1, TICKS + 1):
+        # Phase 0: commit each federate's (t-1) decisions; arm the tick.
+        commit_tick(ship_ctx, t)
+        commit_tick(torp_ctx, t)
+        # Phase 1: publish end-of-(t-1) positions; the in-process broadcast
+        #          synchronously updates the PEER ctx.remote via ProxySink.
+        publish_local(ship_ctx, ship_tx)   # -> torp_ctx.remote gets ship + decoys
+        publish_local(torp_ctx, torp_tx)   # -> ship_ctx.remote gets torpedo
+        # Phase 2: each snapshot = local items + reflected remote peers.
+        ship_ctx.snapshot.refresh(list(ship_ctx.items) + list(ship_ctx.remote.values()))
+        torp_ctx.snapshot.refresh(list(torp_ctx.items) + list(torp_ctx.remote.values()))
+        # Phase 3: advance each federate one tick (no cross-fed interaction now).
+        ship_se.step(t)
+        torp_se.step(t)
+        # Phase 4: record LOCAL live positions from both federates.
+        record(rows, t, ship_ctx.items)
+        record(rows, t, torp_ctx.items)
+
+    ship_fed.resign()
+    torp_fed.resign()
+    print(f"federation members after resign: {len(federation.members)}")
+    return rows
+
+
+def main():
+    tag, path = resolve_scenario(sys.argv[1] if len(sys.argv) > 1 else None)
+    rows = sorted(run(path))
+    out = os.path.join(os.path.dirname(__file__), f"hla_{tag}.csv")
+    with open(out, "w") as f:
+        f.write("tick,object_name,x,y,z\n")
+        for r in rows:
+            f.write(",".join(str(c) for c in r) + "\n")
+    print(f"wrote {out} ({len(rows)} rows)")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/hla_atsim/run_hla_pitch.py
+++ b/examples/hla_atsim/run_hla_pitch.py
@@ -1,0 +1,152 @@
+"""OPTIONAL live Pitch (pRTI 1516e) run of the two-federate anti-torpedo sim.
+
+This is NOT part of the equivalence gate — the gate (verify_equivalence.py)
+uses only the in-process backend and needs no Java. This script is a
+best-effort bridge to a real RTI and is guarded: if the JVM / prti1516e.jar
+/ a reachable CRC are not available it prints a skip message and exits 0.
+
+Each federate runs in its own thread driving Federate.run_until with
+lookahead = 1.0; the local physics is pumped exactly like the in-process
+build (commit_tick -> publish_local -> snapshot.refresh -> step), so the
+same deterministic 1-tick snapshot discipline applies.
+
+Env:
+  PYJEVSIM_JVM   path to jvm.dll   (default: Adoptium JDK 11)
+  PYJEVSIM_JAR   path to prti1516e.jar (default: C:\\Program Files\\prti1516e\\lib)
+
+Run:  python examples/hla_atsim/run_hla_pitch.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import threading
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+sys.path.insert(0, os.path.dirname(__file__))
+
+FOM = os.path.join(os.path.dirname(__file__), "fom", "AntiTorpedo.xml")
+
+JVM_PATH = os.environ.get(
+    "PYJEVSIM_JVM",
+    r"C:\Program Files\Eclipse Adoptium\jdk-11.0.31.11-hotspot\bin\server\jvm.dll",
+)
+JAR = os.environ.get(
+    "PYJEVSIM_JAR",
+    r"C:\Program Files\prti1516e\lib\prti1516e.jar",
+)
+TICKS = 30
+
+
+def _preflight():
+    """Return None if runnable, else a human-readable skip reason."""
+    try:
+        import jpype  # noqa: F401
+    except Exception as e:
+        return f"jpype not importable ({e})"
+    if not os.path.exists(JVM_PATH):
+        return f"JVM not found at {JVM_PATH} (set PYJEVSIM_JVM)"
+    if not os.path.exists(JAR):
+        return f"prti1516e.jar not found at {JAR} (set PYJEVSIM_JAR)"
+    return None
+
+
+def run(scenario=None):
+    reason = _preflight()
+    if reason is not None:
+        print(f"[skip] Pitch run not available: {reason}")
+        return None
+
+    from pyjevsim import ExecutionType, SysExecutor
+    from pyjevsim.hla import Federate, HLAExecutorFactory, create_rti
+
+    from utils.sim_context import SimContext
+    from utils.builder import load_scenario, build_ship, build_torpedo
+    from utils.ticking import commit_tick
+    from hla_common import (
+        PLATFORM_FOM, PLATFORM_OUT, PLATFORM_IN,
+        ANTITORPEDO_FOM_MAP, ProxySink, publish_local,
+    )
+    from run_standalone_headless import record, SCENARIO, resolve_scenario
+    if scenario is None:
+        scenario = SCENARIO
+
+    data = load_scenario(scenario)
+
+    def build_fed(fed_name, model, ctx):
+        se = SysExecutor(_time_resolution=1, ex_mode=ExecutionType.HLA_TIME)
+        ctx.set_executor(se)
+        tx = create_rti(
+            "pitch",
+            federation="AntiTorpedo",
+            federate=fed_name,
+            fom=FOM,
+            fom_map=ANTITORPEDO_FOM_MAP,
+            jvm_path=JVM_PATH,
+            classpath=[JAR],
+            lookahead=1.0,
+        )
+        se.exec_factory = HLAExecutorFactory(tx, {})
+        se.insert_input_port("start")
+        se.register_entity(model)
+        se.coupling_relation(se, "start", model, "start")
+        se.init_sim()
+        se.insert_external_event("start", None)
+        fed = Federate(se, tx)
+        fed.join("AntiTorpedo", fed_name, fom_paths=[FOM])
+        fed.publish(PLATFORM_OUT)
+        fed.subscribe(PLATFORM_IN)
+        se.exec_factory._router.subscribe("attribute", PLATFORM_FOM, ProxySink(ctx))
+        return se, tx, fed
+
+    ship_ctx, torp_ctx = SimContext(), SimContext()
+    ship = build_ship("blue_ship_0", data["SurfaceShip"][0], ship_ctx)
+    torp = build_torpedo("red_torpedo_0", data["Torpedo"][0], torp_ctx)
+
+    try:
+        ship_se, ship_tx, ship_fed = build_fed("ship", ship, ship_ctx)
+        torp_se, torp_tx, torp_fed = build_fed("torpedo", torp, torp_ctx)
+    except Exception as e:
+        print(f"[skip] could not join federation (CRC not reachable?): {e}")
+        return None
+
+    rows_lock = threading.Lock()
+    rows = []
+
+    def drive(se, ctx, tx, other_ready):
+        for t in range(1, TICKS + 1):
+            commit_tick(ctx, t)
+            publish_local(ctx, tx)
+            # request a grant to t (lookahead 1); real RTI blocks until peer
+            tx.request_time_advance(float(t))
+            ctx.snapshot.refresh(list(ctx.items) + list(ctx.remote.values()))
+            se.step(t)
+            with rows_lock:
+                record(rows, t, ctx.items)
+
+    th_s = threading.Thread(target=drive, args=(ship_se, ship_ctx, ship_tx, None))
+    th_t = threading.Thread(target=drive, args=(torp_se, torp_ctx, torp_tx, None))
+    th_s.start(); th_t.start()
+    th_s.join(); th_t.join()
+
+    ship_fed.resign(); torp_fed.resign()
+    return sorted(rows)
+
+
+def main():
+    from run_standalone_headless import resolve_scenario
+    tag, path = resolve_scenario(sys.argv[1] if len(sys.argv) > 1 else None)
+    rows = run(path)
+    if rows is None:
+        return
+    out = os.path.join(os.path.dirname(__file__), f"hla_pitch_{tag}.csv")
+    with open(out, "w") as f:
+        f.write("tick,object_name,x,y,z\n")
+        for r in rows:
+            f.write(",".join(str(c) for c in r) + "\n")
+    print(f"wrote {out} ({len(rows)} rows)")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/hla_atsim/run_standalone_headless.py
+++ b/examples/hla_atsim/run_standalone_headless.py
@@ -1,0 +1,91 @@
+"""Standalone (single-executor) reference run of the anti-torpedo scenario.
+
+Uses the 1-tick snapshot sensing convention (detectors read end-of-previous
+-tick positions) so the trajectories are fully deterministic and match the
+HLA in-process build exactly. Dumps a CSV: tick,object_name,x,y,z.
+
+Run:  python examples/hla_atsim/run_standalone_headless.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+# Prefer the dev source tree over any installed pyjevsim wheel, and make
+# model.* / mobject.* / utils.* resolve as top-level packages.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+sys.path.insert(0, os.path.dirname(__file__))
+
+from pyjevsim import ExecutionType, SysExecutor  # noqa: E402
+
+from utils.sim_context import SimContext  # noqa: E402
+from utils.builder import load_scenario, build_ship, build_torpedo  # noqa: E402
+from utils.ticking import commit_tick  # noqa: E402
+
+SCENARIO_DIR = os.path.join(os.path.dirname(__file__), "scenarios")
+SCENARIOS = {
+    "self_propelled": os.path.join(SCENARIO_DIR, "self_propelled_decoy.yaml"),
+    "stationary":     os.path.join(SCENARIO_DIR, "stationary_decoy.yaml"),
+}
+DEFAULT_SCENARIO = "self_propelled"
+SCENARIO = SCENARIOS[DEFAULT_SCENARIO]   # back-compat default (path); imported by the HLA runners
+TICKS = 30
+
+
+def resolve_scenario(selector=None):
+    """Map a selector to (tag, path). None -> $PYJEVSIM_SCENARIO -> default;
+    a registry key -> its path; otherwise treat selector as a yaml path.
+    `tag` names the per-scenario CSV file."""
+    if selector is None:
+        selector = os.environ.get("PYJEVSIM_SCENARIO", DEFAULT_SCENARIO)
+    if selector in SCENARIOS:
+        return selector, SCENARIOS[selector]
+    return os.path.splitext(os.path.basename(selector))[0], selector
+
+
+def record(rows, t, items):
+    for o in sorted(items, key=lambda o: o.sense_id):
+        x, y, z = o.get_position()
+        rows.append((t, o.sense_id, "%.10g" % x, "%.10g" % y, "%.10g" % z))
+
+
+def run(scenario=SCENARIO):
+    ctx = SimContext()
+    se = SysExecutor(_time_resolution=1, ex_mode=ExecutionType.HLA_TIME)
+    ctx.set_executor(se)
+
+    data = load_scenario(scenario)
+    ship = build_ship("blue_ship_0", data["SurfaceShip"][0], ctx)
+    torp = build_torpedo("red_torpedo_0", data["Torpedo"][0], ctx)
+
+    se.insert_input_port("start")
+    for m in (ship, torp):
+        se.register_entity(m)
+        se.coupling_relation(se, "start", m, "start")
+
+    se.init_sim()
+    se.insert_external_event("start", None)
+
+    rows = []
+    for t in range(1, TICKS + 1):
+        commit_tick(ctx, t)               # apply (t-1) decisions; arm tick
+        ctx.snapshot.refresh(ctx.items)   # end-of-(t-1) positions
+        se.step(t)
+        record(rows, t, ctx.items)        # end-of-t live positions
+    return rows
+
+
+def main():
+    tag, path = resolve_scenario(sys.argv[1] if len(sys.argv) > 1 else None)
+    rows = sorted(run(path))
+    out = os.path.join(os.path.dirname(__file__), f"standalone_{tag}.csv")
+    with open(out, "w") as f:
+        f.write("tick,object_name,x,y,z\n")
+        for r in rows:
+            f.write(",".join(str(c) for c in r) + "\n")
+    print(f"wrote {out} ({len(rows)} rows)")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/hla_atsim/scenarios/self_propelled_decoy.yaml
+++ b/examples/hla_atsim/scenarios/self_propelled_decoy.yaml
@@ -1,0 +1,59 @@
+Common:
+  Name: self_propelled_decoy
+SurfaceShip:
+  - ManueverObject:
+      x: 0
+      y: 0
+      z: 0
+      heading: 0
+      xy_speed: 3
+      z_speed: 0
+    LauncherObject:
+      DecoyObjects:
+        - type: "self_propelled"
+          elevation: 45
+          azimuth: 45
+          speed: 7
+          lifespan: 10
+          heading: 270
+          xy_speed: 2
+        - type: "self_propelled"
+          elevation: 45
+          azimuth: 135
+          speed: 10
+          lifespan: 10
+          heading: 180
+          xy_speed: 2
+        - type: "self_propelled"
+          elevation: 45
+          azimuth: 225
+          speed: 10
+          lifespan: 10
+          heading: 225
+          xy_speed: 2
+        - type: "self_propelled"
+          elevation: 45
+          azimuth: 315
+          speed: 10
+          lifespan: 10
+          heading: 315
+          xy_speed: 2
+    DetectorObject:
+      detection_range: 40
+    CommandControlObject:
+      evation_heading: 270
+      decoy_deployment_range: 35
+
+Torpedo:
+  - ManueverObject:
+      x: 20
+      y: 20
+      z: -10
+      heading: 270
+      xy_speed: 5
+      z_speed: 1
+    DetectorObject:
+      detection_range: 35 
+    TorpedoControlObject:
+      range: 1
+    

--- a/examples/hla_atsim/scenarios/stationary_decoy.yaml
+++ b/examples/hla_atsim/scenarios/stationary_decoy.yaml
@@ -1,0 +1,51 @@
+Common:
+  Name: stationary_decoy
+
+SurfaceShip:
+  - ManueverObject:
+      x: 0
+      y: 0
+      z: 0
+      heading: 0
+      xy_speed: 3
+      z_speed: 0
+    LauncherObject:
+      DecoyObjects:
+        - type: "stationary"
+          elevation: 45
+          azimuth: 45
+          speed: 15
+          lifespan: 5
+        - type: "stationary"
+          elevation: 45
+          azimuth: 135
+          speed: 15
+          lifespan: 5
+        - type: "stationary"
+          elevation: 45
+          azimuth: 225
+          speed: 15
+          lifespan: 5
+        - type: "stationary"
+          elevation: 45
+          azimuth: 315
+          speed: 15
+          lifespan: 5
+    DetectorObject:
+      detection_range: 40
+    CommandControlObject:
+      evation_heading: 270
+      decoy_deployment_range: 35
+
+Torpedo:
+  - ManueverObject:
+      x: 20
+      y: 20
+      z: -10
+      heading: 270
+      xy_speed: 5
+      z_speed: 1
+    DetectorObject:
+      detection_range: 35
+    TorpedoControlObject:
+      range: 1

--- a/examples/hla_atsim/utils/builder.py
+++ b/examples/hla_atsim/utils/builder.py
@@ -1,0 +1,21 @@
+"""Scenario loading + platform construction, ctx-injected (no singleton)."""
+
+import yaml
+
+from model.surfaceship import SurfaceShip
+from model.torpedo import Torpedo
+
+
+def load_scenario(path):
+    with open(path, "r") as f:
+        return yaml.safe_load(f)
+
+
+def build_ship(name, data, ctx):
+    """data = one entry of yaml['SurfaceShip']."""
+    return SurfaceShip(name, data, ctx)
+
+
+def build_torpedo(name, data, ctx):
+    """data = one entry of yaml['Torpedo']."""
+    return Torpedo(name, data, ctx)

--- a/examples/hla_atsim/utils/sensing.py
+++ b/examples/hla_atsim/utils/sensing.py
@@ -1,0 +1,77 @@
+"""Snapshot-based sensing primitives for hla_atsim.
+
+Replaces the live ``ObjectDB().items`` reads with a *frozen* per-tick
+position snapshot. Detectors read the snapshot instead of live objects so
+that the Manuever(writer)/Detector(reader) order within a tick is
+irrelevant — reads are always end-of-previous-tick and order-independent
+(iteration is sorted by a stable ``sense_id``).
+
+The same mechanism serves both builds:
+  * standalone : snapshot fed from the single executor's local items.
+  * HLA        : snapshot fed from local items + reflected peer/decoy
+                 positions (``RemoteObject`` proxies).
+"""
+
+
+class FrozenProxy:
+    """Immutable end-of-tick view of one sensible object."""
+
+    __slots__ = ("sense_id", "kind", "_pos", "_active")
+
+    def __init__(self, sense_id, kind, pos, active):
+        self.sense_id = sense_id
+        self.kind = kind
+        self._pos = tuple(pos)
+        self._active = bool(active)
+
+    def get_position(self):
+        return self._pos
+
+    def check_active(self):
+        return self._active
+
+
+class RemoteObject:
+    """Mutable holder updated by ProxySink from reflected HLA attributes."""
+
+    __slots__ = ("sense_id", "kind", "x", "y", "z", "active")
+
+    def __init__(self, sense_id, kind, x, y, z, active):
+        self.sense_id = sense_id
+        self.kind = kind
+        self.x = x
+        self.y = y
+        self.z = z
+        self.active = active
+
+    def get_position(self):
+        return (self.x, self.y, self.z)
+
+    def check_active(self):
+        return self.active
+
+
+class PositionSnapshot:
+    """A per-tick, order-independent snapshot keyed by stable ``sense_id``."""
+
+    def __init__(self):
+        self._by_id = {}
+
+    def refresh(self, objects):
+        """Freeze the given objects' positions/active flags.
+
+        ``objects`` : any objects exposing ``.sense_id``, ``.kind``,
+        ``get_position()`` and ``check_active()``.
+        """
+        self._by_id = {
+            o.sense_id: FrozenProxy(o.sense_id, o.kind,
+                                    o.get_position(), o.check_active())
+            for o in objects
+        }
+
+    def get(self, sense_id):
+        return self._by_id.get(sense_id)
+
+    def entries(self):
+        """Deterministic: sorted by stable id, never set/hash order."""
+        return [self._by_id[k] for k in sorted(self._by_id)]

--- a/examples/hla_atsim/utils/sim_context.py
+++ b/examples/hla_atsim/utils/sim_context.py
@@ -1,0 +1,26 @@
+"""Per-federate simulation context — replaces the global ObjectDB singleton.
+
+A singleton is fatal for the HLA build: ``run_hla_inprocess.py`` runs *two*
+``SysExecutor`` federates in one process, and each federate needs its own
+``items``/``decoys``/owning ``executor``/``snapshot``. Standalone uses one
+shared ``SimContext``; HLA uses two (one per federate).
+"""
+
+from utils.sensing import PositionSnapshot
+
+
+class SimContext:
+    def __init__(self):
+        self.items = []        # local physics objs (ManueverObject + decoy objs)
+        self.decoys = []       # list of (name, obj)
+        self.removed = []      # sense_ids pruned this tick (HLA -> active=0)
+        self.executor = None   # the SysExecutor this platform runs in
+        self.snapshot = PositionSnapshot()
+        self.remote = {}       # sense_id -> RemoteObject (HLA reflected peers)
+        self.tick = 0          # current tick index (armed by commit_tick)
+
+    def set_executor(self, se):
+        self.executor = se
+
+    def get_executor(self):
+        return self.executor

--- a/examples/hla_atsim/utils/ticking.py
+++ b/examples/hla_atsim/utils/ticking.py
@@ -1,0 +1,44 @@
+"""Tick-boundary bookkeeping that makes the physics deterministic.
+
+The copied atsim models mutate shared physics objects inside ``output()``.
+Under DEVS cascades the *order* in which imminent models fire at one instant
+is decided by ``ScheduleQueue.pop()`` set-iteration (object-id based), and
+some models fire a variable number of times per tick. That makes the raw
+models nondeterministic run-to-run and standalone != HLA.
+
+We remove every intra-tick ordering dependency with two rules, applied
+uniformly to both builds:
+
+  * **Once-per-tick integration** — each Manuever / decoy integrates its
+    physics exactly once per tick (guarded by ``ctx.tick``), so the number
+    and order of ``output()`` calls within a tick no longer matters.
+
+  * **Tick-boundary decision commit** — cross-model decisions that mutate a
+    peer's physics object (CommandControl's heading change, TorpedoControl's
+    pursuit target) are *staged* as ``pending_*`` during a tick and
+    *committed* to the live object at the next tick boundary. Motion in tick
+    ``t`` therefore reads decisions frozen at the end of tick ``t-1`` — the
+    same 1-tick-delay discipline the detector snapshot already uses.
+
+Both builds run identical models over identical frozen inputs, so the
+trajectories are bit-for-bit equal and reproducible.
+"""
+
+
+def commit_tick(ctx, t):
+    """Commit staged decisions from tick ``t-1`` and arm the tick counter.
+
+    Call once per federate at the tick boundary, *before* ``step(t)``.
+    """
+    for o in ctx.items:
+        pending_h = getattr(o, "pending_heading", None)
+        if pending_h is not None:
+            o.heading = pending_h
+        o.pending_heading = None
+
+        # committed_target reflects the *previous* tick's pursuit decision
+        # (None when there was none); pending is then cleared.
+        o.committed_target = getattr(o, "pending_target", None)
+        o.pending_target = None
+
+    ctx.tick = t

--- a/examples/hla_atsim/verify_equivalence.py
+++ b/examples/hla_atsim/verify_equivalence.py
@@ -1,0 +1,49 @@
+"""Equivalence gate: standalone vs HLA-inprocess trajectories must match.
+
+Runs both builds and asserts identical trajectory CSVs (tick,object,x,y,z),
+printing a per-row first-divergence on mismatch and "MATCH: <n> rows" on
+success. Exits non-zero on any mismatch so CI can gate on it.
+
+Run:  python examples/hla_atsim/verify_equivalence.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+sys.path.insert(0, os.path.dirname(__file__))
+
+from run_standalone_headless import run as run_standalone, resolve_scenario, SCENARIOS  # noqa: E402
+from run_hla_inprocess import run as run_hla  # noqa: E402
+
+
+def check(tag, path):
+    a = sorted(run_standalone(path))
+    b = sorted(run_hla(path))
+    if len(a) != len(b):
+        print(f"MISMATCH {tag}: row counts {len(a)} vs {len(b)}")
+        for i, (ra, rb) in enumerate(zip(a, b)):
+            if ra != rb:
+                print(f"FIRST DIVERGENCE {tag} at row {i}:\n  standalone={ra}\n  hla={rb}")
+                break
+        return False
+    for i, (ra, rb) in enumerate(zip(a, b)):
+        if ra != rb:
+            print(f"FIRST DIVERGENCE {tag} at row {i}:\n  standalone={ra}\n  hla={rb}")
+            return False
+    print(f"MATCH {tag}: {len(a)} rows")
+    return True
+
+
+def main():
+    ok = True
+    for tag in ("self_propelled", "stationary"):   # self_propelled first = regression guard
+        if not check(tag, SCENARIOS[tag]):
+            ok = False
+    sys.exit(0 if ok else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Adds **`examples/hla_atsim`** — an HLA/RTI co-simulation of the `examples/atsim`
anti-torpedo scenario, split into **two federates** (surfaceship + torpedo) that
reproduce the standalone trajectories **byte-for-byte**.

## Design

- `examples/atsim` shares object positions through a global `ObjectDB` singleton
  (each `Detector` reads every other object's position from it). This co-sim
  replaces that shared memory with **HLA `Platform` object attributes**
  (`fom/AntiTorpedo.xml`, IEEE 1516-2010): each federate publishes its own hull +
  decoy positions and reflects the peer's into a **per-federate 1-tick snapshot**
  that the detectors read from.
- Bidirectional sensing forbids zero lookahead (causality cycle), so positions
  are exchanged with **lookahead = 1 tick**; both the standalone and federated
  builds use the same snapshot pipeline, which makes the comparison deterministic
  and byte-identical (see the timing analysis baked into the code comments).
- Decoys are ship-owned (spawned at runtime by the ship's `Launcher`) and
  published as HLA objects so the torpedo federate senses them.

## Scenarios & runs

- Two scenarios — **self_propelled** and **stationary** decoys — selectable via
  `PYJEVSIM_SCENARIO` (default `self_propelled`).
- `run_standalone_headless.py` — single-executor reference.
- `run_hla_inprocess.py` — two federates over `InProcessRTI` (no Java).
- `run_hla_pitch.py` — two federates over **live Pitch pRTI** (optional; needs
  JPype + Java ≥ 9 + a running CRC).

## Verification

`verify_equivalence.py` asserts `standalone == federated` **byte-identical for
both scenarios** (180 rows each). Independently verified:

```
MATCH self_propelled: 180 rows
MATCH stationary:      180 rows
```

and for each scenario `standalone.csv == hla.csv (InProcessRTI) == hla_pitch.csv
(live Pitch pRTI)`, byte-for-byte. Physically meaningful: the torpedo is seduced
onto a decoy; stationary decoys hold position while self-propelled ones run out.

`examples/atsim` and `pyjevsim` are unchanged; generated CSVs and `__pycache__`
are gitignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)