### PR TITLE
docs: hla_atsim two-scenario guide + README/Sphinx cross-links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- ``examples/hla_atsim`` — the ``atsim`` anti-torpedo scenario split into two
+  HLA federates (surfaceship + torpedo) exchanging positions as HLA object
+  attributes, reproducing the single-executor reference byte-for-byte for the
+  self-propelled and stationary decoy scenarios (verified on the in-process bus
+  and on live Pitch pRTI via ``verify_equivalence.py``).
+
 ## [2.1.2] — 2026-06-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -152,6 +152,11 @@ The [`examples/`](examples/) directory contains:
   federation join/resign, interaction exchange, and object-attribute
   synchronization. Run offline (`run_inprocess.py`, no Java) or against a
   live Pitch pRTI (`run_pitch.py`).
+- **`hla_atsim/`** — the `atsim` anti-torpedo scenario split into two HLA
+  federates (surfaceship + torpedo) exchanging positions as HLA object
+  attributes. Reproduces the single-executor reference **byte-for-byte**
+  for both the self-propelled and stationary decoy scenarios, verified on
+  the in-process bus and on live Pitch pRTI (`verify_equivalence.py`).
 
 ### Output messages are shared by reference
 

--- a/docs/source/pyjevsim_hla.rst
+++ b/docs/source/pyjevsim_hla.rst
@@ -134,6 +134,34 @@ or against a live Pitch pRTI (``pitch`` backend, with a CRC running)::
 
    python examples/hla_pingpong/run_pitch.py
 
+Anti-torpedo co-simulation (hla_atsim)
+--------------------------------------
+
+``examples/hla_atsim/`` is a larger, verification-driven example: it splits
+the ``examples/atsim`` anti-torpedo scenario into **two federates**
+(surfaceship + torpedo). In the standalone ``atsim`` the platforms sense one
+another through a shared global registry; the HLA version replaces that with
+**HLA object attributes** — each federate publishes its own hull and decoy
+positions and reflects the peer's into a per-federate one-tick position
+snapshot that the detectors read from (bidirectional sensing requires
+``lookahead = 1``).
+
+The example ships two decoy scenarios, ``self_propelled`` (default) and
+``stationary`` (select with ``PYJEVSIM_SCENARIO`` or a CLI argument), and a
+gate that proves the federated run reproduces a single-executor reference
+**byte-for-byte** for both::
+
+   python examples/hla_atsim/verify_equivalence.py
+   # -> MATCH self_propelled: 180 rows
+   # -> MATCH stationary: 180 rows
+
+The same trajectories are produced by the single-process reference
+(``run_standalone_headless.py``), the two-federate in-process bus
+(``run_hla_inprocess.py``), and two federates over a live Pitch pRTI
+(``run_hla_pitch.py``) — identical in every case. This demonstrates that the
+RTI-mediated position exchange faithfully reproduces the monolithic
+simulation's dynamics.
+
 Low-level stepping
 ------------------
 

--- a/examples/hla_atsim/README.md
+++ b/examples/hla_atsim/README.md
@@ -42,6 +42,44 @@ PYJEVSIM_SCENARIO=stationary python examples/hla_atsim/run_hla_inprocess.py
 CSVs are named `standalone_<tag>.csv` / `hla_<tag>.csv` where `<tag>` is the
 scenario key (`self_propelled`, `stationary`); all generated CSVs are gitignored.
 
+## Two scenarios
+
+Two decoy scenarios ship, selected with `PYJEVSIM_SCENARIO` (or a positional
+CLI arg); both mirror the corresponding `examples/atsim` scenario:
+
+| scenario | decoys | behaviour |
+|----------|--------|-----------|
+| `self_propelled` (default) | 4 self-propelled | decoys run outward on their own headings; the torpedo is seduced onto a moving decoy |
+| `stationary` | 4 stationary | decoys hold their drop positions; the torpedo is seduced onto a fixed decoy |
+
+Each scenario is verified **byte-identical** across three execution paths — the
+single-process reference and the two-federate HLA co-simulation on both the
+in-process bus and a real RTI:
+
+| run script | backend | Java? |
+|------------|---------|-------|
+| `run_standalone_headless.py` | single `SysExecutor` (reference) | no |
+| `run_hla_inprocess.py` | two federates, `InProcessRTI` | no |
+| `run_hla_pitch.py` | two federates, **live Pitch pRTI 1516e** | yes (JPype + running CRC) |
+
+For each scenario, `standalone_<tag>.csv` == `hla_<tag>.csv` ==
+`hla_pitch_<tag>.csv`, 180 rows, byte-for-byte:
+
+```
+MATCH self_propelled: 180 rows
+MATCH stationary:      180 rows
+```
+
+To reproduce all six runs and the two-scenario gate:
+
+```bash
+python examples/hla_atsim/verify_equivalence.py                       # both scenarios, no Java
+for s in self_propelled stationary; do
+  python examples/hla_atsim/run_standalone_headless.py $s
+  python examples/hla_atsim/run_hla_inprocess.py       $s
+done
+```
+
 ## Why standalone == HLA, deterministically
 
 The only cross-platform coupling in atsim is *sensing* (each Detector read


### PR DESCRIPTION
Documentation for the `hla_atsim` example (merged in #24).

- **`examples/hla_atsim/README.md`** — new "Two scenarios" section: run/verify
  for both `self_propelled` and `stationary`, and the byte-identical result
  across the single-executor reference, `InProcessRTI`, and live Pitch pRTI.
- **`README.md`** — `hla_atsim` added to the Examples list.
- **`docs/source/pyjevsim_hla.rst`** — new "Anti-torpedo co-simulation
  (hla_atsim)" section.
- **`CHANGELOG.md`** — `[Unreleased]` note.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)