### PR TITLE
chore(deps): bump dev/docs pins to clear all Dependabot alerts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,14 +8,14 @@ dill==0.4.1
 docutils==0.22.4
 fonttools==4.63.0
 id==1.6.1
-idna==3.11
+idna==3.15
 iniconfig==2.3.0
 jaraco.classes==3.4.0
 jaraco.context==6.1.2
 jaraco.functools==4.4.0
 keyring==25.7.0
 kiwisolver==1.5.0
-lxml==6.0.2
+lxml==6.1.0
 markdown-it-py==4.0.0
 matplotlib==3.10.9
 mdurl==0.1.2
@@ -23,7 +23,7 @@ more-itertools==11.0.2
 nh3==0.3.4
 numpy==2.4.6
 packaging==26.0
-pillow==12.0.0
+pillow==12.2.0
 pluggy==1.6.0
 Pygments==2.20.0
 pyjevsim @ file:///D:/development/pyjevsim/dist/pyjevsim-1.3.0-py3-none-any.whl#sha256=ef9690d273f76afb8a74d5e7a43b698bf4825a11550be2bac5b6edaba236688d
@@ -44,7 +44,8 @@ rfc3986==2.0.0
 rich==14.3.4
 shiboken6==6.11.1
 six==1.17.0
+soupsieve==2.8.4
 twine==6.2.0
 typing_extensions==4.15.0
-urllib3==2.6.3
+urllib3==2.7.0
 xlsxwriter==3.2.9

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -17,7 +17,7 @@ Pygments==2.20.0
 pytest==9.0.3
 requests==2.33.0
 snowballstemmer==2.2.0
-soupsieve==2.6
+soupsieve==2.8.4
 Sphinx==8.1.3
 sphinx-basic-ng==1.0.0b2
 sphinx-prompt==1.9.0


### PR DESCRIPTION
Clears the **14 open Dependabot alerts**. All are in the pinned **dev/docs** environments (`requirements.txt`, `requirements_docs.txt`) — **not** the released package. pyjevsim's only runtime dependency is `dill` (`pyproject.toml`), so users installing from PyPI are unaffected; this is repo/CI hygiene.

| package | from | to | severity |
|---------|------|----|----------|
| pillow | 12.0.0 | 12.2.0 | HIGH×3, MED×3 |
| soupsieve | 2.6 (docs) / — | 2.8.4 | HIGH×4 |
| urllib3 | 2.6.3 | 2.7.0 | HIGH×2 |
| lxml | 6.0.2 | 6.1.0 | HIGH×1 |
| idna | 3.11 | 3.15 | MED×1 |

`soupsieve` was flagged transitively for `requirements.txt`, so it is now pinned explicitly at the patched version. `pyproject.toml` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)