### PR TITLE
chore(deps): drop stale self-reference from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,6 @@ packaging==26.0
 pillow==12.2.0
 pluggy==1.6.0
 Pygments==2.20.0
-pyjevsim @ file:///D:/development/pyjevsim/dist/pyjevsim-1.3.0-py3-none-any.whl#sha256=ef9690d273f76afb8a74d5e7a43b698bf4825a11550be2bac5b6edaba236688d
 pyparsing==3.3.2
 pyproject_hooks==1.2.0
 PySide6==6.11.1
@@ -49,3 +48,8 @@ twine==6.2.0
 typing_extensions==4.15.0
 urllib3==2.7.0
 xlsxwriter==3.2.9
+
+# The pyjevsim package itself, installed editable from the repo root
+# (replaces a stale, machine-specific local-wheel path). Runtime deps live
+# in pyproject.toml; this file is the pinned dev/tooling environment.
+-e .


### PR DESCRIPTION
`requirements.txt` pinned the package to a machine-specific local wheel:

```
pyjevsim @ file:///D:/development/pyjevsim/dist/pyjevsim-1.3.0-py3-none-any.whl#sha256=...
```

That path exists only on one machine and pins an old version (1.3.0), so `pip install -r requirements.txt` fails on any other environment. Replaced with a portable editable install (`-e .`) that resolves to the current package.

- Verified: `pip install -e . --dry-run` → *"Would install pyjevsim-2.1.2"*.
- CI does not consume this file (the pylint workflow installs its own deps).
- Runtime deps remain declared in `pyproject.toml` (only `dill`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)