### PR TITLE
fix(docs): unpin pluggy to unblock the Read the Docs build

### DIFF
--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -12,7 +12,7 @@ iniconfig==2.0.0
 Jinja2==3.1.6
 MarkupSafe==3.0.2
 packaging==23.2
-pluggy==1.3.0
+pluggy==1.6.0
 Pygments==2.20.0
 pytest==9.0.3
 requests==2.33.0


### PR DESCRIPTION
## Problem

`pyjevsim.readthedocs.io` (both `/latest` and `/stable`) still shows **pre-2.1 documentation** — none of the 2.1 HLA / RTI content appears, even though it has been on `main` and in the `v2.1.2` tag for a while.

## Root cause

`requirements_docs.txt` pins an **unsatisfiable** combination:

```
pytest==9.0.3      # requires pluggy>=1.5
pluggy==1.3.0
```

Read the Docs runs `pip install -r requirements_docs.txt` *before* invoking Sphinx. The resolver fails with `ResolutionImpossible`, so **no build runs at all** — RTD keeps serving the last successful (pre-2.1) build for every version.

```
ERROR: Cannot install -r requirements_docs.txt (line 17) and pluggy==1.3.0
because these package versions have conflicting dependencies.
```

## Fix

Bump `pluggy` `1.3.0` → `1.6.0` (satisfies pytest 9's `pluggy>=1.5,<2`).

## Verification (local, RTD-style)

```
pip install -r requirements_docs.txt        # now resolves (exit 0)
python -m sphinx -b html docs/source _build  # build succeeded, 7 warnings; exit 0
```
The generated `index.html` contains the `HLA / RTI Integration` page, `IEEE 1516`, and the `pyjevsim_hla` toctree entry. The 7 warnings are pre-existing and benign (autodoc can't import the 5 `banksim` run-scripts, which `open("scenario.yaml")` at import time, plus one box-drawing char in `benchmark.rst`).

## After merge

RTD should rebuild `latest` from `main` automatically. `stable` is tied to the `v2.1.2` tag, whose `requirements_docs.txt` still has the bad pin — it will pick up the fix with the next tagged release (or by setting the RTD default version to `latest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)