### PR TITLE
fix(docs): update .readthedocs.yaml to a supported build image

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,5 +1,7 @@
+version: 2
+
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
     python: "3.10"
 


### PR DESCRIPTION
## Problem

A Read the Docs build now fails at **config validation**, before install/Sphinx run:

```
Config validation error in build.os. Expected one of
(ubuntu-22.04, ubuntu-24.04, ubuntu-26.04, ubuntu-lts-latest),
got type str (ubuntu-20.04).
```

RTD has deprecated the `ubuntu-20.04` build image. (This is a separate, earlier-stage blocker than the `pluggy` install conflict fixed in #35 — that fix is still needed for the install step, but the build never reached it while the OS was invalid.)

## Fix

`.readthedocs.yaml`:
- `build.os`: `ubuntu-20.04` → **`ubuntu-24.04`** (supported LTS; `tools.python: "3.10"` is provided by RTD independently of the image).
- Add the required **`version: 2`** top-level key (the config already uses v2-only keys like `build.os`; making it explicit guards against further validator tightening).

```yaml
version: 2

build:
  os: ubuntu-24.04
  tools:
    python: "3.10"

python:
  install:
    - requirements: requirements_docs.txt

sphinx:
  configuration: docs/source/conf.py
```

With this + #35, an RTD build of `latest` should pass config validation → install → Sphinx (verified locally: `sphinx exit=0`, HLA pages present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)